### PR TITLE
v0.5.2: sponsor logo upload + nav restructure + schedule admin

### DIFF
--- a/CampClotNot/Data/Entities/Sponsor.cs
+++ b/CampClotNot/Data/Entities/Sponsor.cs
@@ -6,7 +6,9 @@ public class Sponsor
     public Guid EventId { get; set; }
     public Event Event { get; set; } = null!;
     public string Name { get; set; } = "";
-    public string LogoUrl { get; set; } = "";
+    public string? LogoUrl { get; set; }
+    public byte[]? LogoData { get; set; }
+    public string? LogoContentType { get; set; }
     public string? Website { get; set; }
     public int SortOrder { get; set; }
 }

--- a/CampClotNot/Migrations/20260602020242_AddSponsorLogoUpload.Designer.cs
+++ b/CampClotNot/Migrations/20260602020242_AddSponsorLogoUpload.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602020242_AddSponsorLogoUpload")]
+    partial class AddSponsorLogoUpload
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260602020242_AddSponsorLogoUpload.cs
+++ b/CampClotNot/Migrations/20260602020242_AddSponsorLogoUpload.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSponsorLogoUpload : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "LogoUrl",
+                table: "Sponsors",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<string>(
+                name: "LogoContentType",
+                table: "Sponsors",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "LogoData",
+                table: "Sponsors",
+                type: "bytea",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LogoContentType",
+                table: "Sponsors");
+
+            migrationBuilder.DropColumn(
+                name: "LogoData",
+                table: "Sponsors");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LogoUrl",
+                table: "Sponsors",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -1,0 +1,384 @@
+@page "/admin/schedule"
+@attribute [Authorize(Roles = "Admin")]
+@inject ScheduleService ScheduleSvc
+@inject LocationService LocationSvc
+@inject MiniGameService MiniGameSvc
+@inject IDbContextFactory<AppDbContext> DbFactory
+@inject AuthenticationStateProvider Auth
+@inject ISnackbar Snackbar
+@using CampClotNot.Data
+@using Microsoft.EntityFrameworkCore
+
+<PageTitle>Schedule Admin — Camp Clot Not</PageTitle>
+
+<div style="padding: 0 16px 100px">
+    <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">📅 Schedule Events</h2>
+
+    <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
+
+        @* ── Form panel ── *@
+        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 340px;min-width:280px">
+            <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Event" : "Edit Event")</h3>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Title</div>
+                <input type="text" @bind="_fTitle" placeholder="e.g. Morning Swim"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Day</div>
+                <input type="date" value="@_fDateStr" min="@_minDate" max="@_maxDate"
+                       @onchange="e => _fDateStr = e.Value?.ToString() ?? string.Empty"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="display:flex;gap:10px;margin-bottom:14px">
+                <div style="flex:1">
+                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Start</div>
+                    <input type="time" value="@_fStartStr"
+                           @onchange="e => _fStartStr = e.Value?.ToString() ?? string.Empty"
+                           style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                </div>
+                <div style="flex:1">
+                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">End (optional)</div>
+                    <input type="time" value="@_fEndStr"
+                           @onchange="e => _fEndStr = e.Value?.ToString() ?? string.Empty"
+                           style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                </div>
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Type</div>
+                <select @bind="_fType"
+                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
+                    @foreach (var t in Enum.GetValues<ScheduleEventType>())
+                    {
+                        <option value="@t">@t</option>
+                    }
+                </select>
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Location (optional)</div>
+                <select value="@(_fLocationId?.ToString() ?? "")"
+                        @onchange="e => _fLocationId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : null"
+                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
+                    <option value="">— None —</option>
+                    @foreach (var loc in _locations)
+                    {
+                        <option value="@loc.LocationId">@loc.Name</option>
+                    }
+                </select>
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Description (optional)</div>
+                <input type="text" @bind="_fDesc" placeholder="Short description"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            @* ── Group Assignments ── *@
+            <div style="border:2px solid #E8E0CC;border-radius:8px;margin-bottom:16px;overflow:hidden">
+                <button type="button"
+                        style="width:100%;padding:10px 12px;background:#F8F4EC;border:none;cursor:pointer;display:flex;justify-content:space-between;align-items:center;gap:8px"
+                        @onclick="() => _assignmentsExpanded = !_assignmentsExpanded">
+                    <div style="display:flex;align-items:center;gap:8px">
+                        <span style="font-family:'Fredoka One',cursive;font-size:13px">Group Assignments</span>
+                        <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:#E8E0CC;color:var(--text-light);font-family:'Fredoka One',cursive">
+                            @(_assignedCount > 0 ? $"{_assignedCount} set" : "Optional")
+                        </span>
+                    </div>
+                    <span style="font-size:11px;color:var(--text-light)">@(_assignmentsExpanded ? "▲" : "▼")</span>
+                </button>
+                @if (!_assignmentsExpanded)
+                {
+                    <div style="padding:6px 12px 8px;font-size:11px;color:var(--text-light);border-top:1px solid #E8E0CC">
+                        Use for rotation slots where each group does a different activity.
+                    </div>
+                }
+                else
+                {
+                    <div style="padding:12px">
+                        @foreach (var row in _fAssignments)
+                        {
+                            var group = _groups.FirstOrDefault(g => g.GroupId == row.GroupId);
+                            <div style="margin-bottom:10px;padding:8px;background:#F8F4EC;border-radius:6px">
+                                <div style="font-family:'Fredoka One',cursive;font-size:12px;color:@(group?.Color ?? "#555");margin-bottom:6px">
+                                    @(group?.Name ?? "—")
+                                </div>
+                                <div style="margin-bottom:6px">
+                                    <div style="font-size:10px;font-weight:900;letter-spacing:1px;text-transform:uppercase;color:var(--text-light);margin-bottom:3px">Activity</div>
+                                    <select value="@(row.ActivityId?.ToString() ?? "")"
+                                            @onchange="e => row.ActivityId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : null"
+                                            style="width:100%;padding:6px 8px;background:var(--bg-base);border:2px solid var(--black);border-radius:5px;font-size:12px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark)">
+                                        <option value="">— None —</option>
+                                        @foreach (var act in _activities)
+                                        {
+                                            <option value="@act.ActivityId">@act.Name</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div style="margin-bottom:6px">
+                                    <div style="font-size:10px;font-weight:900;letter-spacing:1px;text-transform:uppercase;color:var(--text-light);margin-bottom:3px">Location override</div>
+                                    <select value="@(row.LocationId?.ToString() ?? "")"
+                                            @onchange="e => row.LocationId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : null"
+                                            style="width:100%;padding:6px 8px;background:var(--bg-base);border:2px solid var(--black);border-radius:5px;font-size:12px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark)">
+                                        <option value="">— None —</option>
+                                        @foreach (var loc in _locations)
+                                        {
+                                            <option value="@loc.LocationId">@loc.Name</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div>
+                                    <div style="font-size:10px;font-weight:900;letter-spacing:1px;text-transform:uppercase;color:var(--text-light);margin-bottom:3px">Note</div>
+                                    <input type="text" value="@(row.Note ?? "")"
+                                           @onchange="e => row.Note = string.IsNullOrEmpty(e.Value?.ToString()) ? null : e.Value!.ToString()"
+                                           style="width:100%;padding:6px 8px;background:var(--bg-base);border:2px solid var(--black);border-radius:5px;font-size:12px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-sizing:border-box" />
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(_error))
+            {
+                <div style="color:#D12B2B;font-size:12px;margin-bottom:10px">@_error</div>
+            }
+
+            <div style="display:flex;gap:8px">
+                <button class="ccn-btn" @onclick="SaveAsync">@(_editingId == Guid.Empty ? "Add Event" : "Save Changes")</button>
+                @if (_editingId != Guid.Empty)
+                {
+                    <button class="ccn-btn" style="background:transparent" @onclick="CancelEdit">Cancel</button>
+                }
+            </div>
+        </div>
+
+        @* ── Table ── *@
+        <div style="flex:1;min-width:300px">
+            @if (_loading)
+            {
+                <MudProgressCircular Indeterminate="true" />
+            }
+            else if (!_events.Any())
+            {
+                <p style="color:var(--text-light);font-family:'Fredoka One',cursive">No events yet. Add the first one →</p>
+            }
+            else
+            {
+                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                    <table style="width:100%;border-collapse:collapse">
+                        <thead>
+                            <tr style="background:var(--black)">
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Day</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Time</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Title</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Type</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Location</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var ev in _events)
+                            {
+                                <tr style="border-bottom:2px solid #E8E0CC">
+                                    <td style="padding:8px 14px;font-size:13px;font-weight:700;white-space:nowrap">@ev.CampDay.ToString("ddd M/d")</td>
+                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid);white-space:nowrap">
+                                        @ev.StartTime.ToString("h:mm tt")
+                                        @if (ev.EndTime.HasValue)
+                                        {
+                                            <span>–@ev.EndTime.Value.ToString("h:mm tt")</span>
+                                        }
+                                    </td>
+                                    <td style="padding:8px 14px;font-size:13px">
+                                        @ev.Title
+                                        @if (!string.IsNullOrEmpty(ev.Description))
+                                        {
+                                            <div style="font-size:11px;color:var(--text-light)">@ev.Description</div>
+                                        }
+                                        @if (ev.EventGroups.Any())
+                                        {
+                                            <div style="font-size:11px;color:var(--text-light)">@ev.EventGroups.Count group assign.</div>
+                                        }
+                                    </td>
+                                    <td style="padding:8px 14px">
+                                        <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
+                                            @ev.EventType
+                                        </span>
+                                    </td>
+                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid)">@(ev.Location?.Name ?? "—")</td>
+                                    <td style="padding:8px 10px">
+                                        <div style="display:flex;gap:4px">
+                                            <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(ev)">Edit</button>
+                                            <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(ev)">Del</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+
+    </div>
+</div>
+
+@code {
+    private List<ScheduleEvent> _events = new();
+    private List<Location> _locations = new();
+    private List<Activity> _activities = new();
+    private List<Group> _groups = new();
+    private bool _loading = true;
+    private Guid _userId;
+    private Guid _editingId;
+
+    private string _fTitle = "";
+    private string _fDateStr = "";
+    private string _fStartStr = "";
+    private string _fEndStr = "";
+    private ScheduleEventType _fType = ScheduleEventType.Activity;
+    private Guid? _fLocationId;
+    private string? _fDesc;
+    private List<AssignmentFormRow> _fAssignments = new();
+    private bool _assignmentsExpanded;
+    private string _error = "";
+
+    private string _minDate = "";
+    private string _maxDate = "";
+
+    private int _assignedCount =>
+        _fAssignments.Count(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note));
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await Auth.GetAuthenticationStateAsync();
+        Guid.TryParse(authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value, out _userId);
+
+        using var dbEvent = DbFactory.CreateDbContext();
+        var campEvent = await dbEvent.Events.FindAsync(SeedService.Id.EventCcn2026);
+        if (campEvent is not null)
+        {
+            _minDate  = campEvent.EffDate.ToString("yyyy-MM-dd");
+            _maxDate  = campEvent.ExpDate.ToString("yyyy-MM-dd");
+            _fDateStr = _minDate;
+        }
+
+        _locations  = await LocationSvc.GetAllAsync();
+        _activities = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
+
+        using var dbGroups = DbFactory.CreateDbContext();
+        _groups = await dbGroups.Groups
+            .Where(g => g.EventId == SeedService.Id.EventCcn2026)
+            .OrderBy(g => g.Name)
+            .ToListAsync();
+
+        _fAssignments = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
+
+        await Reload();
+    }
+
+    private async Task Reload()
+    {
+        _events  = await ScheduleSvc.GetByEventAsync(SeedService.Id.EventCcn2026);
+        _loading = false;
+    }
+
+    private void StartEdit(ScheduleEvent ev)
+    {
+        _editingId   = ev.ScheduleEventId;
+        _fTitle      = ev.Title;
+        _fDesc       = ev.Description;
+        _fDateStr    = ev.CampDay.ToString("yyyy-MM-dd");
+        _fStartStr   = ev.StartTime.ToString("HH:mm");
+        _fEndStr     = ev.EndTime?.ToString("HH:mm") ?? "";
+        _fType       = ev.EventType;
+        _fLocationId = ev.LocationId;
+        _fAssignments = _groups.Select(g =>
+        {
+            var existing = ev.EventGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
+            return new AssignmentFormRow
+            {
+                GroupId    = g.GroupId,
+                ActivityId = existing?.ActivityId,
+                LocationId = existing?.LocationId,
+                Note       = existing?.Note
+            };
+        }).ToList();
+        _assignmentsExpanded = ev.EventGroups.Any();
+        _error = "";
+    }
+
+    private void CancelEdit()
+    {
+        _editingId           = Guid.Empty;
+        _fTitle              = "";
+        _fDesc               = null;
+        _fDateStr            = _minDate;
+        _fStartStr           = "";
+        _fEndStr             = "";
+        _fType               = ScheduleEventType.Activity;
+        _fLocationId         = null;
+        _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
+        _assignmentsExpanded = false;
+        _error               = "";
+    }
+
+    private async Task SaveAsync()
+    {
+        _error = "";
+        if (string.IsNullOrWhiteSpace(_fTitle))    { _error = "Title is required."; return; }
+        if (string.IsNullOrWhiteSpace(_fDateStr))  { _error = "Day is required."; return; }
+        if (string.IsNullOrWhiteSpace(_fStartStr)) { _error = "Start time is required."; return; }
+        if (!DateOnly.TryParseExact(_fDateStr,  "yyyy-MM-dd", out var day))   { _error = "Invalid date."; return; }
+        if (!TimeOnly.TryParseExact(_fStartStr, "HH:mm", out var start))      { _error = "Invalid start time."; return; }
+        TimeOnly? end = string.IsNullOrEmpty(_fEndStr) ? null
+            : TimeOnly.TryParseExact(_fEndStr, "HH:mm", out var et) ? et : null;
+
+        var assignments = _fAssignments
+            .Where(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note))
+            .Select(a => new GroupAssignmentDto(a.GroupId, a.ActivityId, a.LocationId, a.Note))
+            .ToList();
+
+        var dto = new ScheduleEventDto(
+            _editingId,
+            SeedService.Id.EventCcn2026,
+            day, start, end,
+            _fTitle.Trim(), _fDesc,
+            _fLocationId, _fType,
+            !assignments.Any(),
+            null, assignments
+        );
+        await ScheduleSvc.UpsertAsync(dto, _userId);
+        Snackbar.Add(_editingId == Guid.Empty ? $"{_fTitle} added." : $"{_fTitle} updated.", Severity.Success);
+        CancelEdit();
+        await Reload();
+    }
+
+    private async Task DeleteAsync(ScheduleEvent ev)
+    {
+        await ScheduleSvc.DeleteAsync(ev.ScheduleEventId);
+        Snackbar.Add($"{ev.Title} deleted.", Severity.Info);
+        await Reload();
+    }
+
+    private static string EventTypeBadgeColor(ScheduleEventType t) => t switch
+    {
+        ScheduleEventType.Meal      => "#E67E22",
+        ScheduleEventType.Travel    => "#2980B9",
+        ScheduleEventType.Free      => "#27AE60",
+        ScheduleEventType.Mandatory => "#D12B2B",
+        _                           => "#8E44AD"
+    };
+
+    private class AssignmentFormRow
+    {
+        public Guid    GroupId    { get; set; }
+        public Guid?   ActivityId { get; set; }
+        public Guid?   LocationId { get; set; }
+        public string? Note       { get; set; }
+    }
+}

--- a/CampClotNot/Pages/Admin/Sponsors.razor
+++ b/CampClotNot/Pages/Admin/Sponsors.razor
@@ -11,7 +11,7 @@
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
+        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Sponsor" : "Edit Sponsor")</h3>
 
             <div style="margin-bottom:14px">
@@ -21,13 +21,31 @@
             </div>
 
             <div style="margin-bottom:14px">
-                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Logo URL *</div>
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Logo — Upload (JPEG/PNG, max 2 MB)</div>
+                <InputFile OnChange="HandleLogoUpload" accept=".jpg,.jpeg,.png"
+                           style="width:100%;font-size:13px;font-family:'Nunito',sans-serif" />
+                @if (!string.IsNullOrWhiteSpace(_uploadError))
+                {
+                    <div style="color:#D12B2B;font-size:12px;margin-top:4px">@_uploadError</div>
+                }
+                @if (_fLogoData is not null)
+                {
+                    <div style="margin-top:8px;font-size:11px;color:var(--text-mid)">✅ File ready to upload</div>
+                }
+                else if (_editingId != Guid.Empty && _currentHasFile)
+                {
+                    <div style="margin-top:8px;font-size:11px;color:var(--text-mid)">Current: uploaded file (leave blank to keep)</div>
+                }
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Logo URL (fallback if no file uploaded)</div>
                 <input type="url" @bind="_fLogoUrl" placeholder="https://..."
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
 
             <div style="margin-bottom:14px">
-                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Website (optional)</div>
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Website URL — clicking logo navigates here (optional)</div>
                 <input type="url" @bind="_fWebsite" placeholder="https://..."
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
@@ -37,6 +55,11 @@
                 <input type="number" @bind="_fSortOrder"
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
+
+            @if (!string.IsNullOrWhiteSpace(_saveError))
+            {
+                <div style="color:#D12B2B;font-size:12px;margin-bottom:10px">@_saveError</div>
+            }
 
             <div style="display:flex;gap:8px">
                 <button class="ccn-btn" @onclick="SaveAsync">@(_editingId == Guid.Empty ? "Add Sponsor" : "Save Changes")</button>
@@ -76,7 +99,8 @@
                                 <tr style="border-bottom:2px solid #E8E0CC">
                                     <td style="padding:10px 14px;font-size:13px;font-weight:700">@s.Name</td>
                                     <td style="padding:8px 14px">
-                                        <img src="@s.LogoUrl" alt="@s.Name" style="height:36px;width:auto;object-fit:contain;border:1px solid #E8E0CC;border-radius:4px;background:white;padding:2px" />
+                                        <img src="@LogoSrc(s)" alt="@s.Name"
+                                             style="height:36px;width:auto;object-fit:contain;border:1px solid #E8E0CC;border-radius:4px;background:white;padding:2px" />
                                     </td>
                                     <td style="padding:10px 14px;font-size:12px;color:var(--text-mid)">
                                         @if (!string.IsNullOrWhiteSpace(s.Website))
@@ -108,9 +132,14 @@
     private bool _loading = true;
     private Guid _editingId;
     private string _fName = "";
-    private string _fLogoUrl = "";
+    private string? _fLogoUrl;
     private string? _fWebsite;
     private int _fSortOrder;
+    private byte[]? _fLogoData;
+    private string? _fLogoContentType;
+    private bool _currentHasFile;
+    private string _uploadError = "";
+    private string _saveError = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -123,32 +152,67 @@
         _sponsors = await SponsorSvc.GetAllForEventAsync(Services.SeedService.Id.EventCcn2026);
     }
 
+    private async Task HandleLogoUpload(InputFileChangeEventArgs e)
+    {
+        _uploadError = "";
+        var file = e.File;
+        if (file.Size > 2 * 1024 * 1024)
+        {
+            _uploadError = "File too large — maximum 2 MB.";
+            return;
+        }
+        using var stream = file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        _fLogoData = ms.ToArray();
+        _fLogoContentType = file.ContentType;
+    }
+
     private void StartEdit(Sponsor s)
     {
-        _editingId  = s.SponsorId;
-        _fName      = s.Name;
-        _fLogoUrl   = s.LogoUrl;
-        _fWebsite   = s.Website;
-        _fSortOrder = s.SortOrder;
+        _editingId      = s.SponsorId;
+        _fName          = s.Name;
+        _fLogoUrl       = s.LogoUrl;
+        _fWebsite       = s.Website;
+        _fSortOrder     = s.SortOrder;
+        _fLogoData      = null;
+        _fLogoContentType = null;
+        _currentHasFile = s.LogoData is not null;
+        _uploadError    = "";
+        _saveError      = "";
     }
 
     private void CancelEdit()
     {
         _editingId = Guid.Empty;
-        _fName = ""; _fLogoUrl = ""; _fWebsite = null; _fSortOrder = 0;
+        _fName = ""; _fLogoUrl = null; _fWebsite = null; _fSortOrder = 0;
+        _fLogoData = null; _fLogoContentType = null; _currentHasFile = false;
+        _uploadError = ""; _saveError = "";
     }
 
     private async Task SaveAsync()
     {
-        if (string.IsNullOrWhiteSpace(_fName) || string.IsNullOrWhiteSpace(_fLogoUrl)) return;
+        _saveError = "";
+        if (string.IsNullOrWhiteSpace(_fName))
+        {
+            _saveError = "Name is required.";
+            return;
+        }
+        if (_fLogoData is null && string.IsNullOrWhiteSpace(_fLogoUrl) && !_currentHasFile)
+        {
+            _saveError = "Provide a logo file or a logo URL.";
+            return;
+        }
         await SponsorSvc.UpsertAsync(new Sponsor
         {
-            SponsorId = _editingId,
-            EventId   = Services.SeedService.Id.EventCcn2026,
-            Name      = _fName.Trim(),
-            LogoUrl   = _fLogoUrl.Trim(),
-            Website   = string.IsNullOrWhiteSpace(_fWebsite) ? null : _fWebsite.Trim(),
-            SortOrder = _fSortOrder
+            SponsorId        = _editingId,
+            EventId          = Services.SeedService.Id.EventCcn2026,
+            Name             = _fName.Trim(),
+            LogoUrl          = string.IsNullOrWhiteSpace(_fLogoUrl) ? null : _fLogoUrl.Trim(),
+            LogoData         = _fLogoData,
+            LogoContentType  = _fLogoContentType,
+            Website          = string.IsNullOrWhiteSpace(_fWebsite) ? null : _fWebsite.Trim(),
+            SortOrder        = _fSortOrder
         });
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
         CancelEdit();
@@ -161,4 +225,7 @@
         Snackbar.Add($"{s.Name} deleted.", Severity.Info);
         await Reload();
     }
+
+    private static string LogoSrc(Sponsor s) =>
+        s.LogoData is not null ? $"/sponsors/logo/{s.SponsorId}" : (s.LogoUrl ?? "");
 }

--- a/CampClotNot/Pages/Dashboard.razor
+++ b/CampClotNot/Pages/Dashboard.razor
@@ -1,4 +1,4 @@
-@page "/"
+@page "/dashboard"
 @attribute [Authorize]
 @inject GroupService GroupSvc
 @inject TransactionService TxSvc

--- a/CampClotNot/Pages/Hub/HubSubNav.razor
+++ b/CampClotNot/Pages/Hub/HubSubNav.razor
@@ -75,9 +75,6 @@
 </style>
 
 <nav class="hub-subnav">
-    <a href="/hub/schedule"      class="hub-tab @(IsActive("/hub/schedule")      ? "active" : "")">
-        <span class="tab-icon">📅</span><span>Schedule</span>
-    </a>
     <a href="/hub/announcements" class="hub-tab @(IsActive("/hub/announcements") ? "active" : "")">
         <span class="tab-icon">📣</span><span>Announcements</span>
     </a>

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -10,12 +10,58 @@
 
 <PageTitle>Schedule — Camp Clot Not</PageTitle>
 
-<HubSubNav />
+<style>
+    .sched-day-tabs {
+        display: flex;
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
+        border: 3px solid var(--black);
+        border-radius: 10px;
+        background: var(--panel-bg);
+        box-shadow: 4px 4px 0 var(--black);
+        margin-bottom: 16px;
+    }
+    .sched-day-tabs::-webkit-scrollbar { display: none; }
+    .sched-day-tab {
+        flex: 1 0 auto;
+        min-width: 64px;
+        padding: 10px 8px;
+        border: none;
+        border-bottom: 4px solid transparent;
+        background: transparent;
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1px;
+        transition: background .1s, border-color .1s;
+        font-family: 'Fredoka One', cursive;
+    }
+    .sched-day-tab:hover { background: rgba(26,26,26,.05); }
+    .sched-day-tab.active {
+        border-bottom-color: var(--black);
+        background: var(--bg-base);
+    }
+    .sched-day-tab .tab-dow  { font-size: 11px; color: var(--text-light); letter-spacing: .5px; text-transform: uppercase; }
+    .sched-day-tab .tab-date { font-size: 18px; color: var(--black); line-height: 1; }
+    .sched-day-tab.active .tab-dow  { color: var(--black); }
+    .sched-day-tab .tab-today {
+        font-size: 9px;
+        padding: 1px 5px;
+        border-radius: 3px;
+        background: var(--color-primary);
+        color: white;
+        letter-spacing: .5px;
+        text-transform: uppercase;
+        margin-top: 1px;
+    }
+</style>
 
 <div style="padding: 0 16px 100px">
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px">
         <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0">📅 Schedule</h2>
-        @if (_canEdit)
+        @if (_canEdit && _selectedDay.HasValue)
         {
             <button class="ccn-btn" @onclick="OpenAddForm">+ Add Event</button>
         }
@@ -25,119 +71,132 @@
     {
         <MudProgressCircular Indeterminate="true" />
     }
-    else if (!_eventsByDay.Any())
+    else if (_campEvent is null)
     {
-        <p style="color:var(--text-light);font-family:'Fredoka One',cursive">No events scheduled yet.</p>
+        <p style="color:var(--text-light);font-family:'Fredoka One',cursive">No active event found.</p>
     }
     else
     {
-        @foreach (var (day, events) in _eventsByDay)
-        {
-            var isToday = day == DateOnly.FromDateTime(DateTime.Today);
-            var expanded = _expandedDays.Contains(day);
-            <div style="border:3px solid var(--black);border-radius:10px;margin-bottom:12px;box-shadow:3px 3px 0 var(--black);overflow:hidden">
-                <button style="width:100%;padding:12px 16px;background:@(isToday ? "var(--color-primary)" : "var(--panel-bg)");border:none;cursor:pointer;display:flex;justify-content:space-between;align-items:center;font-family:'Fredoka One',cursive;font-size:16px;color:@(isToday ? "white" : "var(--black)")"
-                        @onclick="() => ToggleDay(day)">
-                    <span>@day.ToString("dddd, MMMM d") @(isToday ? "— TODAY" : "")</span>
-                    <span>@(expanded ? "▲" : "▼") (@events.Count)</span>
+        @* ── Day tabs ── *@
+        <div class="sched-day-tabs">
+            @foreach (var day in AllCampDays())
+            {
+                var isToday = day == DateOnly.FromDateTime(DateTime.Today);
+                <button class="sched-day-tab @(day == _selectedDay ? "active" : "")"
+                        @onclick="() => _selectedDay = day">
+                    <span class="tab-dow">@day.ToString("ddd")</span>
+                    <span class="tab-date">@day.Day</span>
+                    @if (isToday) { <span class="tab-today">TODAY</span> }
                 </button>
-                @if (expanded)
-                {
-                    <div style="padding:8px 0">
-                        @foreach (var ev in events)
-                        {
-                            var myAssignment = _userGroupId.HasValue
-                                ? ev.EventGroups.FirstOrDefault(eg => eg.GroupId == _userGroupId.Value)
-                                : null;
+            }
+        </div>
 
-                            <div style="padding:10px 16px;border-bottom:2px solid #E8E0CC;display:flex;gap:12px;align-items:flex-start">
-                                <div style="min-width:70px;font-family:'Fredoka One',cursive;font-size:13px;color:var(--text-light)">
-                                    @ev.StartTime.ToString("h:mm tt")
-                                    @if (ev.EndTime.HasValue)
-                                    {
-                                        <br />@ev.EndTime.Value.ToString("h:mm tt")
-                                    }
-                                </div>
-                                <div style="flex:1;min-width:0">
-                                    @* Title: show assigned activity name for volunteers/staff with a group *@
-                                    @if (myAssignment?.Activity is not null)
-                                    {
-                                        <div style="font-family:'Fredoka One',cursive;font-size:15px">@myAssignment.Activity.Name</div>
-                                        <div style="font-size:12px;color:var(--text-light);font-style:italic">@ev.Title</div>
-                                    }
-                                    else
-                                    {
-                                        <div style="font-family:'Fredoka One',cursive;font-size:15px">@ev.Title</div>
-                                    }
+        @* ── Events for selected day ── *@
+        @if (_selectedDay.HasValue)
+        {
+            var dayEvents = _eventsByDay.GetValueOrDefault(_selectedDay.Value, []);
+            @if (!dayEvents.Any())
+            {
+                <p style="color:var(--text-light);font-family:'Fredoka One',cursive;padding:16px 0">
+                    No events scheduled for this day.
+                    @if (_canEdit) { <span> Tap <strong>+ Add Event</strong> to add one.</span> }
+                </p>
+            }
+            else
+            {
+                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);overflow:hidden">
+                    @foreach (var ev in dayEvents)
+                    {
+                        var myAssignment = _userGroupId.HasValue
+                            ? ev.EventGroups.FirstOrDefault(eg => eg.GroupId == _userGroupId.Value)
+                            : null;
 
-                                    @* Location: group override takes priority *@
-                                    @{
-                                        var displayLocation = myAssignment?.Location ?? ev.Location;
-                                    }
-                                    @if (displayLocation is not null)
-                                    {
-                                        <div style="font-size:13px;color:var(--text-light)">📍 @displayLocation.Name</div>
-                                    }
-                                    else if (!string.IsNullOrEmpty(myAssignment?.Note))
-                                    {
-                                        <div style="font-size:13px;color:var(--text-light)">@myAssignment.Note</div>
-                                    }
-
-                                    <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
-                                        @ev.EventType
-                                    </span>
-
-                                    @* Admin/Staff: show all-groups assignment table *@
-                                    @if (_isAdminOrStaff && ev.EventGroups.Any())
-                                    {
-                                        <details style="margin-top:8px">
-                                            <summary style="font-size:12px;color:var(--text-light);cursor:pointer;font-family:'Fredoka One',cursive">
-                                                Group assignments (@ev.EventGroups.Count)
-                                            </summary>
-                                            <div style="margin-top:6px;border:2px solid #E8E0CC;border-radius:6px;overflow:hidden">
-                                                @foreach (var eg in ev.EventGroups.OrderBy(x => x.Group.Name))
-                                                {
-                                                    <div style="display:flex;gap:8px;align-items:center;padding:6px 10px;border-bottom:1px solid #E8E0CC;font-size:13px">
-                                                        <span style="font-family:'Fredoka One',cursive;color:@eg.Group.Color;min-width:36px">@eg.Group.ShortName</span>
-                                                        <span style="flex:1">@(eg.Activity?.Name ?? "—")</span>
-                                                        @if (eg.Location is not null)
-                                                        {
-                                                            <span style="color:var(--text-light)">📍 @eg.Location.Name</span>
-                                                        }
-                                                        @if (!string.IsNullOrEmpty(eg.Note))
-                                                        {
-                                                            <span style="color:var(--text-light);font-style:italic">@eg.Note</span>
-                                                        }
-                                                    </div>
-                                                }
-                                            </div>
-                                        </details>
-                                    }
-                                </div>
-                                @if (_canEdit)
+                        <div style="padding:10px 16px;border-bottom:2px solid #E8E0CC;display:flex;gap:12px;align-items:flex-start">
+                            <div style="min-width:70px;font-family:'Fredoka One',cursive;font-size:13px;color:var(--text-light)">
+                                @ev.StartTime.ToString("h:mm tt")
+                                @if (ev.EndTime.HasValue)
                                 {
-                                    <div style="display:flex;gap:4px;flex-shrink:0">
-                                        <button class="ccn-btn" style="font-size:11px;padding:4px 8px" @onclick="() => OpenEditForm(ev)">Edit</button>
-                                        <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => DeleteEvent(ev.ScheduleEventId)">Del</button>
-                                    </div>
+                                    <br />@ev.EndTime.Value.ToString("h:mm tt")
                                 }
                             </div>
-                        }
-                    </div>
-                }
-            </div>
+                            <div style="flex:1;min-width:0">
+                                @if (myAssignment?.Activity is not null)
+                                {
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px">@myAssignment.Activity.Name</div>
+                                    <div style="font-size:12px;color:var(--text-light);font-style:italic">@ev.Title</div>
+                                }
+                                else
+                                {
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px">@ev.Title</div>
+                                }
+
+                                @{
+                                    var displayLocation = myAssignment?.Location ?? ev.Location;
+                                }
+                                @if (displayLocation is not null)
+                                {
+                                    <div style="font-size:13px;color:var(--text-light)">📍 @displayLocation.Name</div>
+                                }
+                                else if (!string.IsNullOrEmpty(myAssignment?.Note))
+                                {
+                                    <div style="font-size:13px;color:var(--text-light)">@myAssignment.Note</div>
+                                }
+
+                                <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
+                                    @ev.EventType
+                                </span>
+
+                                @if (_isAdminOrStaff && ev.EventGroups.Any())
+                                {
+                                    <details style="margin-top:8px">
+                                        <summary style="font-size:12px;color:var(--text-light);cursor:pointer;font-family:'Fredoka One',cursive">
+                                            Group assignments (@ev.EventGroups.Count)
+                                        </summary>
+                                        <div style="margin-top:6px;border:2px solid #E8E0CC;border-radius:6px;overflow:hidden">
+                                            @foreach (var eg in ev.EventGroups.OrderBy(x => x.Group.Name))
+                                            {
+                                                <div style="display:flex;gap:8px;align-items:center;padding:6px 10px;border-bottom:1px solid #E8E0CC;font-size:13px">
+                                                    <span style="font-family:'Fredoka One',cursive;color:@eg.Group.Color;min-width:36px">@eg.Group.ShortName</span>
+                                                    <span style="flex:1">@(eg.Activity?.Name ?? "—")</span>
+                                                    @if (eg.Location is not null)
+                                                    {
+                                                        <span style="color:var(--text-light)">📍 @eg.Location.Name</span>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(eg.Note))
+                                                    {
+                                                        <span style="color:var(--text-light);font-style:italic">@eg.Note</span>
+                                                    }
+                                                </div>
+                                            }
+                                        </div>
+                                    </details>
+                                }
+                            </div>
+                            @if (_canEdit)
+                            {
+                                <div style="display:flex;gap:4px;flex-shrink:0">
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 8px" @onclick="() => OpenEditForm(ev)">Edit</button>
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => DeleteEvent(ev.ScheduleEventId)">Del</button>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            }
         }
     }
 </div>
 
 @if (_showForm)
 {
-    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px" @onclick="CloseForm">
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:12px;box-shadow:4px 4px 0 var(--black);padding:24px;width:100%;max-width:560px;max-height:90vh;overflow-y:auto" @onclick:stopPropagation>
+    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .2s ease" @onclick="CloseForm">
+        <div class="ccn-panel" style="padding:24px;width:100%;max-width:560px;max-height:90vh;overflow-y:auto;box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease" @onclick:stopPropagation>
             <h3 style="font-family:'Fredoka One',cursive;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Event" : "Edit Event")</h3>
 
             <MudTextField @bind-Value="_fTitle"    Label="Title" Required="true" Class="mb-3" />
-            <MudDatePicker @bind-Date="_fDate"     Label="Day" Required="true" Class="mb-3" />
+            <MudDatePicker @bind-Date="_fDate"     Label="Day" Required="true" Class="mb-3"
+                           MinDate="_campEvent is not null ? (DateTime?)_campEvent.EffDate.ToDateTime(TimeOnly.MinValue) : null"
+                           MaxDate="_campEvent is not null ? (DateTime?)_campEvent.ExpDate.ToDateTime(TimeOnly.MinValue) : null" />
             <MudTimePicker @bind-Time="_fStart"    Label="Start Time" Required="true" Class="mb-3" />
             <MudTimePicker @bind-Time="_fEnd"      Label="End Time (optional)" Class="mb-3" />
             <MudSelect @bind-Value="_fType"        Label="Event Type" Class="mb-3">
@@ -148,7 +207,6 @@
             </MudSelect>
             <MudTextField @bind-Value="_fDesc"     Label="Description (optional)" Lines="2" Class="mb-3" />
 
-            @* Location picker *@
             <MudSelect @bind-Value="_fLocationId" Label="Location (optional)" Class="mb-3" Clearable="true">
                 @foreach (var loc in _locations)
                 {
@@ -156,7 +214,6 @@
                 }
             </MudSelect>
 
-            @* Group assignments section — collapsible, optional *@
             @{
                 var assignedCount = _fAssignments.Count(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note));
             }
@@ -232,8 +289,9 @@
     private bool _isAdminOrStaff;
     private bool _showForm;
     private Guid? _userGroupId;
+    private Event? _campEvent;
+    private DateOnly? _selectedDay;
     private Dictionary<DateOnly, List<ScheduleEvent>> _eventsByDay = new();
-    private HashSet<DateOnly> _expandedDays = new();
     private List<Location> _locations = new();
     private List<Activity> _activities = new();
     private List<Group> _groups = new();
@@ -254,11 +312,10 @@
     protected override async Task OnInitializedAsync()
     {
         var authState = await Auth.GetAuthenticationStateAsync();
-        _canEdit       = authState.User.IsInRole("Admin");
+        _canEdit        = authState.User.IsInRole("Admin");
         _isAdminOrStaff = authState.User.IsInRole("Admin") || authState.User.IsInRole("Staff");
         Guid.TryParse(authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value, out _userId);
 
-        // Load the user's group (for Volunteer schedule filtering)
         if (!_isAdminOrStaff && _userId != Guid.Empty)
         {
             using var db = DbFactory.CreateDbContext();
@@ -268,9 +325,17 @@
                 .FirstOrDefaultAsync();
         }
 
+        using var dbEvent = DbFactory.CreateDbContext();
+        _campEvent = await dbEvent.Events.FindAsync(SeedService.Id.EventCcn2026);
+
+        // Default selected day: today if within camp dates, otherwise first camp day
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        _selectedDay = (_campEvent is not null && today >= _campEvent.EffDate && today <= _campEvent.ExpDate)
+            ? today
+            : _campEvent?.EffDate;
+
         _locations = await LocationSvc.GetAllAsync();
-        var allActs = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
-        _activities = allActs;
+        _activities = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
 
         using var dbGroups = DbFactory.CreateDbContext();
         _groups = await dbGroups.Groups
@@ -285,7 +350,6 @@
     {
         var events = await ScheduleSvc.GetByEventAsync(SeedService.Id.EventCcn2026);
 
-        // Volunteers without a group see all-groups events only
         if (!_isAdminOrStaff && !_userGroupId.HasValue)
             events = events.Where(e => e.AppliesToAllGroups).ToList();
 
@@ -294,25 +358,21 @@
             .OrderBy(g => g.Key)
             .ToDictionary(g => g.Key, g => g.OrderBy(e => e.StartTime).ToList());
 
-        var today = DateOnly.FromDateTime(DateTime.Today);
-        if (_eventsByDay.ContainsKey(today))
-            _expandedDays.Add(today);
-        else if (_eventsByDay.Any())
-            _expandedDays.Add(_eventsByDay.Keys.First());
-
         _loading = false;
     }
 
-    private void ToggleDay(DateOnly day)
+    private IEnumerable<DateOnly> AllCampDays()
     {
-        if (!_expandedDays.Remove(day)) _expandedDays.Add(day);
+        if (_campEvent is null) yield break;
+        for (var d = _campEvent.EffDate; d <= _campEvent.ExpDate; d = d.AddDays(1))
+            yield return d;
     }
 
     private void OpenAddForm()
     {
         _editingId   = Guid.Empty;
         _fTitle      = ""; _fDesc = null;
-        _fDate       = DateTime.Today;
+        _fDate       = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
         _fStart      = new TimeSpan(9, 0, 0); _fEnd = null;
         _fType       = ScheduleEventType.Activity;
         _fLocationId = null;
@@ -364,10 +424,13 @@
             TimeOnly.FromTimeSpan(_fStart.Value),
             _fEnd.HasValue ? TimeOnly.FromTimeSpan(_fEnd.Value) : null,
             _fTitle, _fDesc, _fLocationId, _fType,
-            !assignments.Any(),   // AppliesToAllGroups = true when no group assignments set
+            !assignments.Any(),
             null, assignments
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
+
+        // Switch to the saved day's tab after save
+        _selectedDay = DateOnly.FromDateTime(_fDate.Value);
         _showForm = false;
         await LoadEvents();
     }

--- a/CampClotNot/Pages/Hub/Sponsors.razor
+++ b/CampClotNot/Pages/Hub/Sponsors.razor
@@ -26,7 +26,7 @@
                 {
                     <a href="@s.Website" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
                         <div class="sponsor-tile">
-                            <img src="@s.LogoUrl" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
+                            <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
                             <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
                         </div>
                     </a>
@@ -34,7 +34,7 @@
                 else
                 {
                     <div class="sponsor-tile">
-                        <img src="@s.LogoUrl" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
+                        <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
                         <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
                     </div>
                 }
@@ -75,4 +75,7 @@
         _sponsors = await SponsorSvc.GetAllForEventAsync(Services.SeedService.Id.EventCcn2026);
         _loading  = false;
     }
+
+    private static string LogoSrc(Sponsor s) =>
+        s.LogoData is not null ? $"/sponsors/logo/{s.SponsorId}" : (s.LogoUrl ?? "");
 }

--- a/CampClotNot/Pages/Index.razor
+++ b/CampClotNot/Pages/Index.razor
@@ -1,0 +1,15 @@
+@page "/"
+@attribute [Authorize]
+@inject NavigationManager Nav
+@inject IHttpContextAccessor HttpContextAccessor
+
+@code {
+    protected override void OnInitialized()
+    {
+        var ctx = HttpContextAccessor.HttpContext;
+        if (ctx is not null && !ctx.Response.HasStarted)
+            ctx.Response.Redirect("/hub/schedule");
+        else
+            Nav.NavigateTo("/hub/schedule", replace: true);
+    }
+}

--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -120,13 +120,21 @@ try
         var email    = form["email"].ToString();
         var password = form["password"].ToString();
         var ok = await auth.LoginAsync(ctx, email, password);
-        return ok ? Results.Redirect("/") : Results.Redirect("/login?error=true");
+        return ok ? Results.Redirect("/hub/schedule") : Results.Redirect("/login?error=true");
     });
 
     app.MapGet("/logout", async (HttpContext ctx) =>
     {
         await ctx.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         ctx.Response.Redirect("/login");
+    });
+
+    // Serve sponsor logos stored as bytea in the database
+    app.MapGet("/sponsors/logo/{id:guid}", async (Guid id, SponsorService svc) =>
+    {
+        var s = await svc.GetByIdAsync(id);
+        if (s?.LogoData is null) return Results.NotFound();
+        return Results.File(s.LogoData, s.LogoContentType ?? "image/jpeg");
     });
 
     app.MapHub<LiveHub>("/livehub");

--- a/CampClotNot/Services/SeedService.cs
+++ b/CampClotNot/Services/SeedService.cs
@@ -309,7 +309,7 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
             EventTypeId = Id.EventTypeCcn,
             ThemeId     = Id.ThemeSuperMarioParty2026,
             Name        = "Camp Clot Not 2026",
-            EffDate     = new DateOnly(2026, 6, 20),
+            EffDate     = new DateOnly(2026, 6, 19),
             ExpDate     = new DateOnly(2026, 6, 25),
             IsActive    = true
         });

--- a/CampClotNot/Services/SponsorService.cs
+++ b/CampClotNot/Services/SponsorService.cs
@@ -6,6 +6,12 @@ namespace CampClotNot.Services;
 
 public class SponsorService(IDbContextFactory<AppDbContext> factory)
 {
+    public async Task<Sponsor?> GetByIdAsync(Guid sponsorId)
+    {
+        using var db = factory.CreateDbContext();
+        return await db.Sponsors.FindAsync(sponsorId);
+    }
+
     public async Task<List<Sponsor>> GetAllForEventAsync(Guid eventId)
     {
         using var db = factory.CreateDbContext();
@@ -27,10 +33,15 @@ public class SponsorService(IDbContextFactory<AppDbContext> factory)
         }
         else
         {
-            existing.Name      = s.Name;
-            existing.LogoUrl   = s.LogoUrl;
-            existing.Website   = s.Website;
-            existing.SortOrder = s.SortOrder;
+            existing.Name            = s.Name;
+            existing.LogoUrl         = s.LogoUrl;
+            existing.Website         = s.Website;
+            existing.SortOrder       = s.SortOrder;
+            if (s.LogoData is not null)
+            {
+                existing.LogoData        = s.LogoData;
+                existing.LogoContentType = s.LogoContentType;
+            }
         }
         await db.SaveChangesAsync();
         return s;

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -70,8 +70,9 @@
         line-height: 1.4;
     }
 
-    /* ── Desktop dropdown panels (activities + admin share the same panel style) ── */
-    .nav-activities-dropdown,
+    /* ── Desktop dropdown panels ── */
+    .nav-hub-dropdown,
+    .nav-game-dropdown,
     .nav-admin-dropdown { position: relative; }
     .nav-admin-panel {
         position: absolute;
@@ -143,9 +144,9 @@
     }
     .nav-tab .tab-icon { font-size: 20px; line-height: 1; }
 
-    /* ── Bottom sheets (activities + admin share the same sheet style) ── */
+    /* ── Bottom sheets ── */
     .nav-admin-sheet,
-    .nav-activities-sheet {
+    .nav-game-sheet {
         position: fixed;
         bottom: calc(60px + env(safe-area-inset-bottom));
         left: 0;
@@ -159,8 +160,8 @@
     }
     .nav-admin-sheet a,
     .nav-admin-sheet button,
-    .nav-activities-sheet a,
-    .nav-activities-sheet button {
+    .nav-game-sheet a,
+    .nav-game-sheet button {
         display: flex;
         align-items: center;
         padding: 16px 20px;
@@ -177,8 +178,8 @@
     }
     .nav-admin-sheet a:last-child,
     .nav-admin-sheet button:last-child,
-    .nav-activities-sheet a:last-child,
-    .nav-activities-sheet button:last-child { border-bottom: none; }
+    .nav-game-sheet a:last-child,
+    .nav-game-sheet button:last-child { border-bottom: none; }
 </style>
 
 @* ── MOBILE HEADER ──────────────────────────────────────────────── *@
@@ -205,35 +206,58 @@
     <AuthorizeView>
         <Authorized>
             <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center">
-                <a href="/" class="nav-link" style="@ActiveStyle("/", "#D12B2B")">📊 Dashboard</a>
+                <a href="/hub/schedule" class="nav-link" style="@ActiveStyle("/hub/schedule", "#2980B9")">📅 Schedule</a>
 
-                @* ── Activities dropdown ── *@
-                <div class="nav-activities-dropdown">
-                    @if (_activitiesDropdownOpen)
+                @* ── Hub dropdown ── *@
+                <div class="nav-hub-dropdown">
+                    @if (_hubDropdownOpen)
                     {
                         <div style="position:fixed;inset:0;z-index:49"
-                             @onclick="() => _activitiesDropdownOpen = false"></div>
+                             @onclick="() => _hubDropdownOpen = false"></div>
                     }
-                    <button class="nav-link" style="@ActivitiesDropdownStyle()"
-                            @onclick="() => { _activitiesDropdownOpen = !_activitiesDropdownOpen; _adminDropdownOpen = false; }">
-                        🎮 Activities @(_activitiesDropdownOpen ? "▲" : "▼")
+                    <button class="nav-link" style="@HubDropdownStyle()"
+                            @onclick="() => { _hubDropdownOpen = !_hubDropdownOpen; _gameDropdownOpen = false; _adminDropdownOpen = false; }">
+                        📋 Hub @(_hubDropdownOpen ? "▲" : "▼")
                     </button>
-                    @if (_activitiesDropdownOpen)
+                    @if (_hubDropdownOpen)
                     {
                         <div class="nav-admin-panel">
-                            <a href="/board"     @onclick="() => _activitiesDropdownOpen = false">🗺️ Board Game</a>
-                            <AuthorizeView Roles="Admin" Context="actAdminCtx">
-                                <a href="/minigames" @onclick="() => _activitiesDropdownOpen = false">🎲 Mini-Game</a>
+                            <a href="/hub/announcements" @onclick="() => _hubDropdownOpen = false">📣 Announcements</a>
+                            <a href="/hub/staff"         @onclick="() => _hubDropdownOpen = false">👥 Staff</a>
+                            <a href="/hub/sponsors"      @onclick="() => _hubDropdownOpen = false">🏆 Sponsors</a>
+                            <a href="/hub/info"          @onclick="() => _hubDropdownOpen = false">📋 Info</a>
+                            <AuthorizeView Roles="Admin" Context="hubAdminCtx">
+                                <a href="/hub/incidents" @onclick="() => _hubDropdownOpen = false">🚨 Incidents</a>
                             </AuthorizeView>
                         </div>
                     }
                 </div>
 
-                <AuthorizeView Roles="Admin,Staff,Volunteer" Context="hubDesktopCtx">
-                    <a href="/hub" class="nav-link" style="@ActiveStyle("/hub", "#2980B9")">📋 Hub</a>
-                </AuthorizeView>
+                @* ── Game dropdown ── *@
+                <div class="nav-game-dropdown">
+                    @if (_gameDropdownOpen)
+                    {
+                        <div style="position:fixed;inset:0;z-index:49"
+                             @onclick="() => _gameDropdownOpen = false"></div>
+                    }
+                    <button class="nav-link" style="@GameDropdownStyle()"
+                            @onclick="() => { _gameDropdownOpen = !_gameDropdownOpen; _hubDropdownOpen = false; _adminDropdownOpen = false; }">
+                        🎮 Game @(_gameDropdownOpen ? "▲" : "▼")
+                    </button>
+                    @if (_gameDropdownOpen)
+                    {
+                        <div class="nav-admin-panel">
+                            <a href="/dashboard" @onclick="() => _gameDropdownOpen = false">📊 Leaderboard</a>
+                            <a href="/board" @onclick="() => _gameDropdownOpen = false">🗺️ Board Game</a>
+                            <AuthorizeView Roles="Admin" Context="gameAdminCtx">
+                                <a href="/minigames" @onclick="() => _gameDropdownOpen = false">🎲 Mini-Game</a>
+                                <button @onclick="() => { _gameDropdownOpen = false; OnLeaderboardClick.InvokeAsync(); }">📺 Projector</button>
+                            </AuthorizeView>
+                        </div>
+                    }
+                </div>
 
-                <AuthorizeView Roles="Admin" Context="adminCtx">
+                <AuthorizeView Roles="Admin" Context="adminDesktopCtx">
                     <a href="/transactions" class="nav-link" style="@ActiveStyle("/transactions", "#2563C4")">📋 Transactions</a>
 
                     <div class="nav-admin-dropdown">
@@ -243,13 +267,14 @@
                                  @onclick="() => _adminDropdownOpen = false"></div>
                         }
                         <button class="nav-link" style="@AdminDropdownStyle()"
-                                @onclick="() => { _adminDropdownOpen = !_adminDropdownOpen; _activitiesDropdownOpen = false; }">
+                                @onclick="() => { _adminDropdownOpen = !_adminDropdownOpen; _hubDropdownOpen = false; _gameDropdownOpen = false; }">
                             ⚙️ Admin @(_adminDropdownOpen ? "▲" : "▼")
                         </button>
                         @if (_adminDropdownOpen)
                         {
                             <div class="nav-admin-panel">
                                 <a href="/admin/games"     @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
+                                <a href="/admin/schedule"  @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
                                 <a href="/admin/groups"    @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
                                 <a href="/admin/users"     @onclick="() => _adminDropdownOpen = false">🔑 Users</a>
                                 <a href="/admin/locations" @onclick="() => _adminDropdownOpen = false">📍 Locations</a>
@@ -259,10 +284,6 @@
                     </div>
                 </AuthorizeView>
 
-                <button class="nav-link" style="@ActiveStyle("/__lbd__", "#F5C800")"
-                        @onclick="OnLeaderboardClick">
-                    📺 Leaderboard
-                </button>
                 <button onclick="window.location='/logout'" class="nav-link"
                         style="border-color:#D12B2B;box-shadow:2px 2px 0 #D12B2B;color:#D12B2B;opacity:.8">
                     Sign Out
@@ -276,34 +297,22 @@
 <AuthorizeView>
     <Authorized>
         <div class="nav-bottom-bar">
-            <a href="/" class="nav-tab @(IsActive("/") ? "active" : "")">
-                <span class="tab-icon">📊</span>
-                <span>Dashboard</span>
+            <a href="/hub/schedule" class="nav-tab @(IsScheduleActive() ? "active" : "")">
+                <span class="tab-icon">📅</span>
+                <span>Schedule</span>
             </a>
-            <AuthorizeView Roles="Admin" Context="mobileActivitiesCtx">
-                <Authorized>
-                    <a href="/transactions" class="nav-tab @(IsActive("/transactions") ? "active" : "")">
-                        <span class="tab-icon">📋</span>
-                        <span>Transactions</span>
-                    </a>
-                </Authorized>
-                <NotAuthorized>
-                    <button class="nav-tab @(IsActivitiesActive() ? "active" : "")"
-                            @onclick="() => { _activitiesSheetOpen = !_activitiesSheetOpen; _adminSheetOpen = false; }">
-                        <span class="tab-icon">🎮</span>
-                        <span>Activities</span>
-                    </button>
-                </NotAuthorized>
-            </AuthorizeView>
-            <AuthorizeView Roles="Admin,Staff,Volunteer" Context="hubMobileCtx">
-                <a href="/hub/schedule" class="nav-tab @(IsActive("/hub") ? "active" : "")">
-                    <span class="tab-icon">📋</span>
-                    <span>Hub</span>
-                </a>
-            </AuthorizeView>
+            <a href="/hub/announcements" class="nav-tab @(IsHubActive() ? "active" : "")">
+                <span class="tab-icon">📋</span>
+                <span>Hub</span>
+            </a>
+            <button class="nav-tab @(IsGameActive() ? "active" : "")"
+                    @onclick="() => { _gameSheetOpen = !_gameSheetOpen; _adminSheetOpen = false; }">
+                <span class="tab-icon">🎮</span>
+                <span>Game</span>
+            </button>
             <AuthorizeView Roles="Admin" Context="mobileAdminCtx">
                 <button class="nav-tab @(_adminSheetOpen ? "active" : "")"
-                        @onclick="() => { _adminSheetOpen = !_adminSheetOpen; _activitiesSheetOpen = false; }">
+                        @onclick="() => { _adminSheetOpen = !_adminSheetOpen; _gameSheetOpen = false; }">
                     <span class="tab-icon">⚙️</span>
                     <span>Admin</span>
                 </button>
@@ -312,15 +321,16 @@
     </Authorized>
 </AuthorizeView>
 
-@* ── ACTIVITIES BOTTOM SHEET (mobile) ────────────────────────────── *@
-@if (_activitiesSheetOpen)
+@* ── GAME BOTTOM SHEET (mobile) ───────────────────────────────────── *@
+@if (_gameSheetOpen)
 {
     <div style="position:fixed;inset:0;z-index:51;background:rgba(26,26,26,.4)"
-         @onclick="() => _activitiesSheetOpen = false"></div>
-    <div class="nav-activities-sheet">
-        <a href="/board"     @onclick="() => _activitiesSheetOpen = false">🗺️ Board Game</a>
+         @onclick="() => _gameSheetOpen = false"></div>
+    <div class="nav-game-sheet">
+        <a href="/dashboard" @onclick="() => _gameSheetOpen = false">📊 Leaderboard</a>
+        <a href="/board"     @onclick="() => _gameSheetOpen = false">🗺️ Board Game</a>
         <AuthorizeView Roles="Admin">
-            <a href="/minigames" @onclick="() => _activitiesSheetOpen = false">🎲 Mini-Game</a>
+            <a href="/minigames" @onclick="() => _gameSheetOpen = false">🎲 Mini-Game</a>
         </AuthorizeView>
     </div>
 }
@@ -333,6 +343,7 @@
     <div class="nav-admin-sheet">
         <a href="/transactions"    @onclick="() => _adminSheetOpen = false">📋 Transactions</a>
         <a href="/admin/games"     @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
+        <a href="/admin/schedule"  @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
         <a href="/admin/groups"    @onclick="() => _adminSheetOpen = false">👥 Groups</a>
         <a href="/admin/users"     @onclick="() => _adminSheetOpen = false">🔑 Users</a>
         <a href="/admin/locations" @onclick="() => _adminSheetOpen = false">📍 Locations</a>
@@ -344,9 +355,10 @@
 @code {
     [Parameter] public EventCallback OnLeaderboardClick { get; set; }
 
-    private bool _activitiesDropdownOpen;
-    private bool _activitiesSheetOpen;
+    private bool _hubDropdownOpen;
+    private bool _gameDropdownOpen;
     private bool _adminDropdownOpen;
+    private bool _gameSheetOpen;
     private bool _adminSheetOpen;
 
     private bool IsActive(string href) =>
@@ -355,21 +367,36 @@
             : ("/" + Nav.ToBaseRelativePath(Nav.Uri))
                 .StartsWith(href, StringComparison.OrdinalIgnoreCase);
 
-    private bool IsActivitiesActive() =>
-        IsActive("/board") || IsActive("/minigames");
+    private bool IsScheduleActive() => IsActive("/hub/schedule");
+
+    private bool IsHubActive()
+    {
+        var path = "/" + Nav.ToBaseRelativePath(Nav.Uri);
+        return path.StartsWith("/hub", StringComparison.OrdinalIgnoreCase)
+            && !path.StartsWith("/hub/schedule", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool IsGameActive() =>
+        IsActive("/dashboard") || IsActive("/board") || IsActive("/minigames");
 
     private string ActiveStyle(string href, string color)
     {
-        var active = href.StartsWith("/__") ? false : IsActive(href);
+        var active = IsActive(href);
         return active
             ? $"border-color:{color};box-shadow:2px 2px 0 {color};background:{color};color:#1A1A1A"
             : "";
     }
 
-    private string ActivitiesDropdownStyle()
+    private string HubDropdownStyle()
     {
-        var active = IsActive("/board") || IsActive("/minigames");
-        return active
+        return IsHubActive()
+            ? "border-color:#2980B9;box-shadow:2px 2px 0 #2980B9;background:#2980B9;color:#1A1A1A"
+            : "";
+    }
+
+    private string GameDropdownStyle()
+    {
+        return IsGameActive()
             ? "border-color:#F5C800;box-shadow:2px 2px 0 #F5C800;background:#F5C800;color:#1A1A1A"
             : "";
     }


### PR DESCRIPTION
## Summary

Merges `dev` → `main` for the v0.5.2 release.

- **Sponsor logo upload** — File upload (JPEG/PNG, 2MB max) stored as bytea; served via `/sponsors/logo/{id}`; URL fallback retained.
- **Nav restructure** — Schedule as primary entry point; Hub dropdown; Game dropdown (absorbs Activities); mobile 4-tab bar.
- **Schedule day tabs** — Horizontal scrollable tabs replace accordion; auto-selects today.
- **Admin schedule CRUD** — `/admin/schedule` for full event management with group assignments.
- **Event start date** — EffDate June 19.

## Migration required

Run `dotnet ef database update` (or Railway will auto-apply on deploy):
`AddSponsorLogoUpload` — adds `LogoData` + `LogoContentType` to `Sponsor`, makes `LogoUrl` nullable.

Generated with [Claude Code](https://claude.com/claude-code)