### PR TITLE
v0.5.3: admin CRUD for mini-game activities (#112)

### DIFF
--- a/CampClotNot/Pages/Admin/Activities.razor
+++ b/CampClotNot/Pages/Admin/Activities.razor
@@ -1,0 +1,134 @@
+@page "/admin/activities"
+@attribute [Authorize(Roles = "Admin")]
+@inject MiniGameService MiniGameSvc
+@inject ISnackbar Snackbar
+
+<PageTitle>Activities — Camp Clot Not</PageTitle>
+
+<div style="padding: 0 16px 100px">
+    <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 4px">🎲 Activities</h2>
+    <p style="font-size:13px;color:var(--text-light);margin:0 0 20px">
+        Mini-game activities available in the evening spinner and schedule group assignments.
+    </p>
+
+    <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
+
+        @* ── Form panel ── *@
+        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
+            <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Activity" : "Edit Activity")</h3>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Name</div>
+                <input type="text" @bind="_fName" placeholder="e.g. Mushroom Kingdom Trivia"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:16px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Description (optional)</div>
+                <input type="text" @bind="_fDescription" placeholder="Short description"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="display:flex;gap:8px">
+                <button class="ccn-btn" @onclick="SaveAsync">@(_editingId == Guid.Empty ? "Add Activity" : "Save Changes")</button>
+                @if (_editingId != Guid.Empty)
+                {
+                    <button class="ccn-btn" style="background:transparent" @onclick="CancelEdit">Cancel</button>
+                }
+            </div>
+        </div>
+
+        @* ── Table ── *@
+        <div style="flex:1;min-width:240px">
+            @if (_loading)
+            {
+                <MudProgressCircular Indeterminate="true" />
+            }
+            else if (!_activities.Any())
+            {
+                <p style="color:var(--text-light);font-family:'Fredoka One',cursive">No activities yet. Add the first one →</p>
+            }
+            else
+            {
+                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                    <table style="width:100%;border-collapse:collapse">
+                        <thead>
+                            <tr style="background:var(--black)">
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Description</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var a in _activities)
+                            {
+                                <tr style="border-bottom:2px solid #E8E0CC">
+                                    <td style="padding:10px 14px;font-size:13px;font-weight:700">@a.Name</td>
+                                    <td style="padding:10px 14px;font-size:13px;color:var(--text-mid)">@(string.IsNullOrEmpty(a.Description) ? "—" : a.Description)</td>
+                                    <td style="padding:8px 10px">
+                                        <div style="display:flex;gap:4px">
+                                            <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(a)">Edit</button>
+                                            <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(a)">Del</button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+
+    </div>
+</div>
+
+@code {
+    private List<Activity> _activities = new();
+    private bool _loading = true;
+    private Guid _editingId;
+    private string _fName = "";
+    private string _fDescription = "";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Reload();
+        _loading = false;
+    }
+
+    private async Task Reload()
+    {
+        _activities = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
+    }
+
+    private void StartEdit(Activity a)
+    {
+        _editingId    = a.ActivityId;
+        _fName        = a.Name;
+        _fDescription = a.Description;
+    }
+
+    private void CancelEdit()
+    {
+        _editingId = Guid.Empty;
+        _fName = ""; _fDescription = "";
+    }
+
+    private async Task SaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_fName)) return;
+        await MiniGameSvc.UpsertActivityAsync(_editingId, SeedService.Id.EventCcn2026, _fName.Trim(), _fDescription.Trim());
+        Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
+        CancelEdit();
+        await Reload();
+    }
+
+    private async Task DeleteAsync(Activity a)
+    {
+        var deleted = await MiniGameSvc.DeleteActivityAsync(a.ActivityId);
+        if (deleted)
+            Snackbar.Add($"{a.Name} deleted.", Severity.Info);
+        else
+            Snackbar.Add($"{a.Name} is assigned to a mini-game script and cannot be deleted.", Severity.Warning);
+        await Reload();
+    }
+}

--- a/CampClotNot/Services/MiniGameService.cs
+++ b/CampClotNot/Services/MiniGameService.cs
@@ -106,4 +106,40 @@ public class MiniGameService(
         await db.SaveChangesAsync();
         await hub.Clients.All.SendAsync("MiniGameSpinReset");
     }
+
+    public async Task UpsertActivityAsync(Guid activityId, Guid eventId, string name, string description)
+    {
+        using var db = factory.CreateDbContext();
+        var existing = await db.Activities.FindAsync(activityId);
+        if (existing is null)
+        {
+            db.Activities.Add(new Activity
+            {
+                ActivityId     = activityId == Guid.Empty ? Guid.NewGuid() : activityId,
+                EventId        = eventId,
+                ActivityTypeId = SeedService.Id.ActTypeMtwiPlaceholder,
+                Name           = name,
+                Description    = description
+            });
+        }
+        else
+        {
+            existing.Name        = name;
+            existing.Description = description;
+        }
+        await db.SaveChangesAsync();
+    }
+
+    // Returns false if the activity is referenced by a triggered script (cannot delete).
+    public async Task<bool> DeleteActivityAsync(Guid activityId)
+    {
+        using var db = factory.CreateDbContext();
+        var inUse = await db.ScriptedMiniGames.AnyAsync(s => s.ActivityId == activityId);
+        if (inUse) return false;
+        var activity = await db.Activities.FindAsync(activityId);
+        if (activity is null) return true;
+        db.Activities.Remove(activity);
+        await db.SaveChangesAsync();
+        return true;
+    }
 }

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -273,8 +273,9 @@
                         @if (_adminDropdownOpen)
                         {
                             <div class="nav-admin-panel">
-                                <a href="/admin/games"     @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
-                                <a href="/admin/schedule"  @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
+                                <a href="/admin/games"      @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
+                                <a href="/admin/activities" @onclick="() => _adminDropdownOpen = false">🎲 Activities</a>
+                                <a href="/admin/schedule"   @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
                                 <a href="/admin/groups"    @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
                                 <a href="/admin/users"     @onclick="() => _adminDropdownOpen = false">🔑 Users</a>
                                 <a href="/admin/locations" @onclick="() => _adminDropdownOpen = false">📍 Locations</a>
@@ -342,8 +343,9 @@
          @onclick="() => _adminSheetOpen = false"></div>
     <div class="nav-admin-sheet">
         <a href="/transactions"    @onclick="() => _adminSheetOpen = false">📋 Transactions</a>
-        <a href="/admin/games"     @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
-        <a href="/admin/schedule"  @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
+        <a href="/admin/games"      @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
+        <a href="/admin/activities" @onclick="() => _adminSheetOpen = false">🎲 Activities</a>
+        <a href="/admin/schedule"   @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
         <a href="/admin/groups"    @onclick="() => _adminSheetOpen = false">👥 Groups</a>
         <a href="/admin/users"     @onclick="() => _adminSheetOpen = false">🔑 Users</a>
         <a href="/admin/locations" @onclick="() => _adminSheetOpen = false">📍 Locations</a>


### PR DESCRIPTION
## Summary

- New `/admin/activities` page — Name + Description form panel, activity table, delete blocked when referenced by a mini-game script
- `MiniGameService.UpsertActivityAsync` + `DeleteActivityAsync`
- Wired into desktop Admin dropdown and mobile admin sheet

Closes #112

## Test plan

- [ ] Add a new activity; verify it appears in the table and in the Games.razor mini-game script dropdown
- [ ] Edit an existing activity name; verify the spinner script page reflects the updated name
- [ ] Delete an activity not referenced by any script; verify it disappears
- [ ] Attempt to delete an activity assigned to a script; verify warning snackbar fires and activity remains

Generated with [Claude Code](https://claude.com/claude-code)