### PR TITLE
fix(#114): schedule event save — wire CreatedBy as FK, drop shadow column

### DIFF
--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -76,8 +76,12 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         // InfoPage: non-conventional PK (PageId, not InfoPageId)
         modelBuilder.Entity<InfoPage>().HasKey(p => p.PageId);
 
-        // ScheduleEvent: non-conventional PK
+        // ScheduleEvent: non-conventional PK; CreatedBy is the FK to Users (not the shadow CreatedByUserUserId)
         modelBuilder.Entity<ScheduleEvent>().HasKey(e => e.ScheduleEventId);
+        modelBuilder.Entity<ScheduleEvent>()
+            .HasOne(e => e.CreatedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.CreatedBy);
 
         // ScheduleEventGroup: composite PK
         modelBuilder.Entity<ScheduleEventGroup>()

--- a/CampClotNot/Migrations/20260602195416_FixScheduleEventCreatedByFK.Designer.cs
+++ b/CampClotNot/Migrations/20260602195416_FixScheduleEventCreatedByFK.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260602195416_FixScheduleEventCreatedByFK")]
+    partial class FixScheduleEventCreatedByFK
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260602195416_FixScheduleEventCreatedByFK.cs
+++ b/CampClotNot/Migrations/20260602195416_FixScheduleEventCreatedByFK.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixScheduleEventCreatedByFK : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedByUserUserId",
+                table: "ScheduleEvents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEvents_CreatedByUserUserId",
+                table: "ScheduleEvents");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedByUserUserId",
+                table: "ScheduleEvents");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEvents_CreatedBy",
+                table: "ScheduleEvents",
+                column: "CreatedBy");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedBy",
+                table: "ScheduleEvents",
+                column: "CreatedBy",
+                principalTable: "Users",
+                principalColumn: "UserId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedBy",
+                table: "ScheduleEvents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEvents_CreatedBy",
+                table: "ScheduleEvents");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CreatedByUserUserId",
+                table: "ScheduleEvents",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEvents_CreatedByUserUserId",
+                table: "ScheduleEvents",
+                column: "CreatedByUserUserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedByUserUserId",
+                table: "ScheduleEvents",
+                column: "CreatedByUserUserId",
+                principalTable: "Users",
+                principalColumn: "UserId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `ScheduleEvent.CreatedByUser` navigation had no explicit FK configuration. EF Core created a shadow property `CreatedByUserUserId` instead of using the existing `CreatedBy` Guid. On every insert, `CreatedByUserUserId` defaulted to `Guid.Empty`, violating the NOT NULL FK constraint and crashing the Blazor circuit (white bar + page freeze).
- **Fix**: Added `HasForeignKey(e => e.CreatedBy)` configuration in `AppDbContext.OnModelCreating`.
- **Migration**: Drops the orphaned `CreatedByUserUserId` shadow column, index, and FK; adds index + FK on `CreatedBy`.

## Test plan
- [ ] Navigate to `/admin/schedule`
- [ ] Fill in Title, Day, and Start time; click **Add Event** — should succeed and show snackbar
- [ ] Verify the event appears in the table
- [ ] Edit the event and save — should update without error
- [ ] Delete the event — should work
- [ ] Repeat add from `/hub/schedule` if that page has a form

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)