### PR TITLE
chore: update CLAUDE.md + REQUIREMENTS.md through v0.5.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,10 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 
 ---
 
-## Current State (as of 2026-05-27)
+## Current State (as of 2026-06-02)
 
-**Active branch:** `feature/103-mobile-pwa-fixes` (v0.5.1 in progress — uncommitted)
-**Released to dev:** v0.5.0 — Camp Info Hub + PWA
+**Active branch:** `main` / `dev` (all feature work merged)
+**Released to main:** v0.5.4 — schedule save bug fix
 
 **v0.1.0 — Done:**
 - Blazor Server project: entities, repositories, services, SignalR hub, MudBlazor pages
@@ -63,7 +63,7 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - `railway.toml` added with `/health` healthcheck, `ON_FAILURE` restart policy
 - Railway production: project `camp-clot-not` live; Postgres running (SFO); env vars set (`DATABASE_URL`, `ASPNETCORE_ENVIRONMENT`, `Seed__AdminEmail`, `Seed__AdminPassword`)
 
-**v0.5.1 — In Progress (feature/103-mobile-pwa-fixes, uncommitted):**
+**v0.5.1 — Done (feature/103-mobile-pwa-fixes, PR #104/105):**
 - User edit dialog on `/admin/users`; PWA `short_name` → "CCN 2026"; `viewport-fit=cover`; desktop nav mobile suppression; bottom nav safe-area padding; Activities → Transactions swap in mobile nav (Admin); PWA icons regenerated from tall 3-row CCN logo; Children's Harbor logo extracted to `wwwroot/img/childrens-harbor-logo.png`
 - `IncidentReport` entity + `IncidentReportService` — submit, list, acknowledge
 - `Sponsor` entity + `SponsorService` — CRUD, ordered by SortOrder
@@ -76,6 +76,25 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - `AppNav.razor` — `/admin/sponsors` in desktop Admin dropdown and mobile admin sheet
 - `SeedService` — `schedule-overview` and `packing` removed from InfoPage seed (and from `SeedService.Id`)
 - EF migration `AddIncidentReportAndSponsor` added and applied
+
+**v0.5.2 — Done (feature/108, PR #110/111):**
+- Sponsor logo upload: `Sponsor` entity extended with `LogoData (byte[]?)` + `LogoContentType (string?)`; logo stored in DB; `/admin/sponsors` serves logos via a streaming endpoint; display pages render `<img src="/sponsor-logo/{id}">` (or fall back to LogoUrl)
+- Nav restructure: Admin dropdown order → Game Admin → Activities → Schedule → Groups → Users → Locations → Sponsors (desktop and mobile sheet)
+- `/hub/schedule` day tabs: collapsible accordion replaced with horizontal day tabs; `_selectedDay` tracks active tab; `_campEvent` loaded for min/max date constraints; sets `_selectedDay` after save
+- `/admin/schedule` (new page): Admin CRUD for `ScheduleEvent` — form panel + table pattern (same as Locations); date/time inputs use `value`+`@onchange` string pattern; group assignments collapsible section; calls `ScheduleService.UpsertAsync`
+- `Index.razor` redirects `/` to `/hub/schedule` via `IHttpContextAccessor`; `Dashboard.razor` route changed from `@page "/"` to `@page "/dashboard"`
+- EF migration `AddSponsorLogoUpload` applied
+
+**v0.5.3 — Done (feature/112, PR #113):**
+- `/admin/activities` (new page): Admin CRUD for MinuteToWinIt activities (Name + Description) — same form panel + table pattern; delete blocked if activity is referenced by a `ScriptedMiniGame`
+- `MiniGameService.UpsertActivityAsync` and `DeleteActivityAsync` added
+- These are the activities Vicki/Amanda can configure: "Mushroom Kingdom Trivia Showdown", "Yoshi Egg Rescue Relay", etc.
+
+**v0.5.4 — Done (feature/114, PR #115/116):**
+- Bug fix: schedule event save caused Blazor circuit crash (white bar + freeze)
+- Root cause: `ScheduleEvent.CreatedByUser` navigation had no explicit FK config; EF Core created shadow property `CreatedByUserUserId`; on insert it defaulted to `Guid.Empty`, violating NOT NULL FK constraint
+- Fix: `HasForeignKey(e => e.CreatedBy)` added to `OnModelCreating`
+- Migration `FixScheduleEventCreatedByFK`: drops `CreatedByUserUserId` shadow column/index/FK; wires `CreatedBy` as the real FK to `Users.UserId`
 
 **Next:** v1.0.0-rc — Dry Run
 
@@ -117,6 +136,8 @@ This file is gitignored and won't exist in a new worktree. EF migrations (`dotne
 Floating action buttons (like "Log Score" and "Report Incident") must use the class `ccn-fab-mobile` with `position:fixed;bottom:24px;right:24px`. The global `ThemeHead.razor` media query `@media (max-width:768px) { .ccn-fab-mobile { bottom: 80px !important; } }` handles bottom-nav clearance on mobile automatically. Do NOT hardcode `calc(80px + env(safe-area-inset-bottom))` — that is always elevated and misses the desktop position.
 
 **12. Modal dialogs — always use the `fadeIn`/`popIn` pattern from `LogTransactionDialog`.**  
+**13. Navigation property names must follow EF Core FK convention or be configured explicitly.**  
+If a navigation property `FooUser` references `User` but the FK property is not named `FooUserUserId` or `UserId`, EF Core creates a shadow property (e.g. `FooUserUserId`) instead of using your named property. The shadow property defaults to `Guid.Empty` on insert, causing a NOT NULL FK constraint violation that crashes the Blazor circuit. Fix: add explicit `.HasForeignKey(e => e.YourProperty)` in `OnModelCreating` whenever the FK property name doesn't match the `<NavName><PKName>` convention. This was the root cause of the v0.5.4 schedule save bug.  
 All form modals must use: backdrop `animation:fadeIn .2s ease` with `rgba(26,26,26,.65)`, panel `ccn-panel` class with `animation:popIn .25s ease` and `box-shadow:8px 8px 0 var(--black)`, and centered with `display:flex;align-items:center;justify-content:center;padding:20px`. Do not use bottom-sheet patterns for forms — they lack the popIn animation and feel inconsistent. A shared `CcnDialog.razor` wrapper is planned post-v0.5.1 once a third dialog exists.
 
 ---
@@ -217,6 +238,8 @@ feature/N-name    — feature branches off dev (N = GitHub issue number, open is
 | `CampClotNot/Pages/MiniGamesDisplay.razor` | Mini-game projector at `/minigames/display` — Admin only |
 | `CampClotNot/Pages/Admin/Games.razor` | Combined game admin at `/admin/games` |
 | `CampClotNot/Pages/Admin/Sponsors.razor` | Sponsor CRUD at `/admin/sponsors` |
+| `CampClotNot/Pages/Admin/Schedule.razor` | Schedule event CRUD at `/admin/schedule` — Admin only |
+| `CampClotNot/Pages/Admin/Activities.razor` | MinuteToWinIt activity CRUD at `/admin/activities` — Admin only |
 | `CampClotNot/Pages/Hub/HubSubNav.razor` | Shared Hub sub-nav + floating Report Incident FAB + modal |
 | `CampClotNot/Pages/Hub/Incidents.razor` | Admin incident list at `/hub/incidents` |
 | `CampClotNot/Pages/Hub/IncidentPrint.razor` | Print view at `/hub/incidents/{id}/print` — uses `PrintLayout` |

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -314,7 +314,7 @@ IncidentReport     — IncidentReportId, EventId, DateOfIncident, DateCompleted,
                      PersonsInvolved, Description, RecommendedAction,
                      SubmittedByUserId, SubmittedByName, SubmittedByRole, SubmittedAt,
                      IsAcknowledged, AcknowledgedByUserId?, AcknowledgedByName?, AcknowledgedAt?
-Sponsor            — SponsorId, EventId, Name, LogoUrl, Website?, SortOrder
+Sponsor            — SponsorId, EventId, Name, LogoUrl?, LogoData (binary)?, LogoContentType?, Website?, SortOrder
 
 -- Future / v1.1+
 PushSubscription   — SubscriptionId, UserId, Endpoint, P256DH, Auth,
@@ -536,7 +536,10 @@ Camp is June 20-25, 2026.
 | ~May 28 | v0.3.1 — UI Overhaul ✅ | Neo-brutalist redesign, cream bg, rank rows, ccn-coin/star assets, real group names & logos |
 | ~May 16 | v0.4.0 — Mini-Games & Display ✅ | Mini-game spinner (3-way split: /minigames, /minigames/display, /admin/games), LiveHub rename, Activities dropdown nav, login page redesign |
 | ~June 7 | v0.5.0 — Camp Info Hub + PWA ✅ | Hub features (§8.1–8.4), PWA manifest + service worker + install flow (§8.9), Railway production setup |
-| ~May 28 | v0.5.1 — Hub Additions (in progress) | Mobile/PWA fixes, Incident Reports (§8.10), Sponsors (§8.11), Info seed cleanup, PrintLayout |
+| ~May 28 | v0.5.1 — Hub Additions ✅ | Mobile/PWA fixes, Incident Reports (§8.10), Sponsors (§8.11), Info seed cleanup, PrintLayout |
+| ~June 2 | v0.5.2 — Schedule Admin + Sponsor Logos ✅ | Sponsor binary logo upload, `/admin/schedule` CRUD, schedule day tabs, nav restructure, `/` → `/hub/schedule` redirect |
+| ~June 2 | v0.5.3 — Activities Admin ✅ | `/admin/activities` CRUD for MinuteToWinIt activities (Vicki/Amanda configurable) |
+| ~June 2 | v0.5.4 — Schedule Save Fix ✅ | Bug fix: EF shadow FK on `ScheduleEvent.CreatedByUser` caused circuit crash on save; explicit `HasForeignKey` + migration |
 | ~June 7-8 | v1.0.0-rc — Dry Run | Full dress rehearsal. Staff test on real devices. Projector verified. Issues logged. |
 | ~June 13 | v1.0.0 — Camp Ready | Dry run issues resolved. Production seeded. Staff briefed. One week buffer. |
 | June 20 | 🏕️ CAMP | Super Clot Not Party '26 is live |
@@ -786,9 +789,11 @@ ScheduleEventGroup — EventId, GroupId  (bridge; only populated when AppliesToA
 - Any staff role can add, edit, delete events — no approval flow
 - Empty state: "No events scheduled for this day — tap + to add one"
 
+**Admin CRUD:** `/admin/schedule` — Admin-only page for pre-loading the full week's schedule before camp. Vicki/Amanda can configure all events. Form panel + table pattern (matching `/admin/locations`). Group assignment overrides (Activity, Location, Note per group) are collapsible within the form.
+
 **Scope boundary:** Staff-only. No camper-facing view in beta. No recurring event support.
 
-**System name:** `ScheduleEvent` / `IScheduleService` / `/hub/schedule`
+**System name:** `ScheduleEvent` / `ScheduleService` / `/hub/schedule` / `/admin/schedule`
 
 ---
 
@@ -1012,13 +1017,17 @@ Admin manages a list of event sponsors (name, logo URL, optional website link, s
 
 **Admin CRUD:** `/admin/sponsors` — same table/form panel pattern as `/admin/locations`. Accessible from Admin desktop dropdown and mobile admin sheet.
 
-**Logo storage:** External URL only — no file upload in v0.5.1.
+**Logo storage:** Binary upload supported as of v0.5.2. `Sponsor` entity has `LogoData (byte[]?)` + `LogoContentType (string?)`. Logo served via streaming endpoint `/sponsor-logo/{id}`. Falls back to `LogoUrl` string if no binary data. `LogoUrl` remains nullable.
 
 **System name:** `Sponsor` / `SponsorService` / `/hub/sponsors`
 
 ---
 
-### 8.12 Shared Dialog Pattern (planned v0.5.2)
+### 8.12 Mini-Game Activities Admin (v0.5.3)
+
+Admin CRUD at `/admin/activities` for MinuteToWinIt activities (e.g. "Mushroom Kingdom Trivia Showdown", "Yoshi Egg Rescue Relay"). Vicki/Amanda can add, rename, and delete activities. Deletion is blocked if the activity is assigned to a `ScriptedMiniGame`. These are the same activities used by the evening spinner and group assignment overrides on schedule events.
+
+### 8.13 Shared Dialog Pattern (planned post-v0.5.1)
 
 All form modals use the same visual shell: `rgba(26,26,26,.65)` backdrop with `animation:fadeIn .2s ease`, centered `ccn-panel` with `animation:popIn .25s ease` and `box-shadow:8px 8px 0 var(--black)`. Currently duplicated across `LogTransactionDialog` and the Report Incident modal in `HubSubNav.razor`.
 
@@ -1245,4 +1254,4 @@ Each exclusion is a deliberate decision, not an oversight. Revisit only if a spe
 ---
 
 *Camp Clot Not · Super Party 2026 · Requirements, Asset Spec & Architecture Guide · Tyler Blair*  
-*Last updated: 2026-05-27 — v0.5.1: §8.10 Incident Reports, §8.11 Sponsors, §8.12 shared dialog pattern; §8.4 seed slugs updated; §8.5 permission matrix updated; data model updated; milestone added*
+*Last updated: 2026-06-02 — v0.5.2–v0.5.4: §8.1 schedule admin CRUD added; §8.11 sponsor binary logo upload; §8.12 activities admin (MinuteToWinIt); §8.13 shared dialog pattern (renumbered); milestones updated; data model updated; Pitfall #13 (EF shadow FK) added to CLAUDE.md*


### PR DESCRIPTION
Updates both reference documents to reflect all completed work:

- **CLAUDE.md**: v0.5.2/5.3/5.4 marked done; Pitfall #13 (EF shadow FK convention that caused the schedule save crash); new admin pages in Key Files table; active branch updated
- **REQUIREMENTS.md**: milestones v0.5.2–5.4 marked done; §8.1 admin schedule CRUD; §8.11 sponsor binary logo upload; §8.12 activities admin; §8.13 shared dialog (renumbered); data model Sponsor updated; footer updated

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)