### PR TITLE
release: v0.5.5 — photos, sponsor enhancements, schedule improvements, dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,16 +98,23 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - Migration `FixScheduleEventCreatedByFK`: drops `CreatedByUserUserId` shadow column/index/FK; wires `CreatedBy` as the real FK to `Users.UserId`
 
 **v0.5.5 — In Progress (feature/118, issue #118):**
-- `IncidentReport` enhancements: `IncidentLocation (string?)` field + `IncidentReportType` enum (`Internal`/`ChildrensHarbor`); Admins can select CH type; all other roles default to `Internal`
-- Remove Mini Marios group from seed → 3 groups total: Blue Shell Bandits, Mushroom Militia, Luma Legends
-- `StaffMember` headshot photo upload: `PhotoData (byte[]?)` + `PhotoContentType (string?)`; `/staff-photo/{id}` endpoint; show in `/hub/staff` card, upload in admin dialog
-- `MedicalStaff` role added to `Role` enum: can log transactions, view+acknowledge incident reports, view all Hub features; no admin panel
-- `Sponsor` enhancements: `ContactName?` + `Phone?` fields; tap-to-call on `/hub/sponsors`; drag-and-drop sort order in `/admin/sponsors`
-- `ScheduleEvent` presenter bios: `PresenterName?` + `PresenterBio?`; shown in `/hub/schedule`; editable in `/admin/schedule`
-- 12-hour AM/PM time format throughout schedule display and admin
-- Dashboard landing page at `/dashboard`: welcome message, Sponsors widget (prominent), today's schedule widget, latest announcement widget, quick nav buttons; `Index.razor` redirects here
 
-**Migration:** `AddV055Enhancements` — adds columns to `IncidentReport`, `StaffMember`, `ScheduleEvent`, `Sponsor`; `Role` enum gets `MedicalStaff` (C# only, no schema change)
+*Entities / enums changed:*
+- `Role` enum: add `MedicalStaff` (C# only — no schema change; stored via UserRole seed). Permissions: log transactions, view+acknowledge incident reports, all Hub features; no admin panel.
+- `ScheduleEventType` enum: add `Presentation` (C# only). `Travel` keeps its code name but displays as "Arrival/Departure" everywhere in the UI.
+- `IncidentReport`: add `IncidentLocationId (Guid? FK→Location)` + `IncidentLocationOther (string?)` + `ReportType (IncidentReportType enum: Internal/ChildrensHarbor)`. Incident form shows location dropdown from active event's locations + always-visible "Other" option (reveals free-text when selected). Admins can choose `ChildrensHarbor` type; all other roles default to `Internal`.
+- `StaffMember`: add `PhotoData (byte[]?)` + `PhotoContentType (string?)`; served via `/staff-photo/{id}`; shows in `/hub/staff` card (falls back to emoji); uploadable in admin dialog.
+- `ScheduleEvent`: add `PresenterName (string?)` + `PresenterBio (string?)`; ONLY shown/editable in admin form when `EventType == Presentation`; only displayed in `/hub/schedule` for Presentation events.
+- `Sponsor`: add `ContactName (string?)` + `Phone (string?)`; tap-to-call `tel:` link on `/hub/sponsors`; drag-and-drop sort in `/admin/sponsors` (admin-only, saves `SortOrder` to DB, drives order for all users).
+- `Location`: add `ImageData (byte[]?)` + `ImageContentType (string?)`; served via `/location-image/{id}`; upload in `/admin/locations` form.
+- `Activity`: add `LocationId (Guid? FK→Location)`; optional location link set in `/admin/activities`; board space rendering (Board.razor, BoardDisplay.razor) uses location image when activity has a location with image.
+
+*Other changes:*
+- Remove Mini Marios group from seed → 3 groups: Blue Shell Bandits, Mushroom Militia, Luma Legends. (Prod DB note: purge will fail if Mini Marios has FK-referenced rows — delete transactions/board positions first.)
+- 12-hour AM/PM time format everywhere in schedule display and admin.
+- Dashboard landing page at `/dashboard`: Sponsors widget (prominent per Vicki), today's schedule, latest announcement, quick nav; `Index.razor` redirects here instead of `/hub/schedule`.
+
+**Migration:** `AddV055Enhancements` — adds columns to `IncidentReport` (LocationId, LocationOther, ReportType), `StaffMember` (PhotoData, PhotoContentType), `ScheduleEvent` (PresenterName, PresenterBio), `Sponsor` (ContactName, Phone), `Location` (ImageData, ImageContentType), `Activity` (LocationId FK).
 
 **Next:** v1.0.0-rc — Dry Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 
 ## Current State (as of 2026-06-02)
 
-**Active branch:** `main` / `dev` (all feature work merged)
+**Active branch:** `feature/118-v055-improvements` (off `dev`)
 **Released to main:** v0.5.4 — schedule save bug fix
+**GitHub issue:** #118 — v0.5.5 scope (see below)
 
 **v0.1.0 — Done:**
 - Blazor Server project: entities, repositories, services, SignalR hub, MudBlazor pages
@@ -95,6 +96,18 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - Root cause: `ScheduleEvent.CreatedByUser` navigation had no explicit FK config; EF Core created shadow property `CreatedByUserUserId`; on insert it defaulted to `Guid.Empty`, violating NOT NULL FK constraint
 - Fix: `HasForeignKey(e => e.CreatedBy)` added to `OnModelCreating`
 - Migration `FixScheduleEventCreatedByFK`: drops `CreatedByUserUserId` shadow column/index/FK; wires `CreatedBy` as the real FK to `Users.UserId`
+
+**v0.5.5 — In Progress (feature/118, issue #118):**
+- `IncidentReport` enhancements: `IncidentLocation (string?)` field + `IncidentReportType` enum (`Internal`/`ChildrensHarbor`); Admins can select CH type; all other roles default to `Internal`
+- Remove Mini Marios group from seed → 3 groups total: Blue Shell Bandits, Mushroom Militia, Luma Legends
+- `StaffMember` headshot photo upload: `PhotoData (byte[]?)` + `PhotoContentType (string?)`; `/staff-photo/{id}` endpoint; show in `/hub/staff` card, upload in admin dialog
+- `MedicalStaff` role added to `Role` enum: can log transactions, view+acknowledge incident reports, view all Hub features; no admin panel
+- `Sponsor` enhancements: `ContactName?` + `Phone?` fields; tap-to-call on `/hub/sponsors`; drag-and-drop sort order in `/admin/sponsors`
+- `ScheduleEvent` presenter bios: `PresenterName?` + `PresenterBio?`; shown in `/hub/schedule`; editable in `/admin/schedule`
+- 12-hour AM/PM time format throughout schedule display and admin
+- Dashboard landing page at `/dashboard`: welcome message, Sponsors widget (prominent), today's schedule widget, latest announcement widget, quick nav buttons; `Index.razor` redirects here
+
+**Migration:** `AddV055Enhancements` — adds columns to `IncidentReport`, `StaffMember`, `ScheduleEvent`, `Sponsor`; `Role` enum gets `MedicalStaff` (C# only, no schema change)
 
 **Next:** v1.0.0-rc — Dry Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,28 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - 12-hour AM/PM time format everywhere in schedule display and admin.
 - Dashboard landing page at `/dashboard`: Sponsors widget (prominent per Vicki), today's schedule, latest announcement, quick nav; `Index.razor` redirects here instead of `/hub/schedule`.
 
-**Migration:** `AddV055Enhancements` — adds columns to `IncidentReport` (LocationId, LocationOther, ReportType), `StaffMember` (PhotoData, PhotoContentType), `ScheduleEvent` (PresenterName, PresenterBio), `Sponsor` (ContactName, Phone), `Location` (ImageData, ImageContentType), `Activity` (LocationId FK).
+**Migration:** `AddV055Enhancements` (`20260603051634`) — DONE. Applied to local dev DB. Adds columns to `IncidentReport` (IncidentLocationId FK, IncidentLocationOther, ReportType), `StaffMember` (PhotoData, PhotoContentType), `ScheduleEvent` (PresenterName, PresenterBio), `Sponsor` (ContactName, Phone), `Location` (ImageData, ImageContentType), `Activity` (LocationId FK).
+
+**v0.5.5 progress as of 2026-06-03:**
+- [x] All entity files updated
+- [x] All enum additions (MedicalStaff in Role, IncidentReportType, Presentation in ScheduleEventType)
+- [x] AppDbContext: explicit FK config for Activity.LocationId and IncidentReport.IncidentLocationId
+- [x] SeedService: MedicalStaff UserRole + LogTransaction authority link; Mini Marios removed; board positions seed uses Group2/3/4
+- [x] Migration AddV055Enhancements created and applied to dev DB
+
+**v0.5.5 remaining (UI + service layer — pick up here next session):**
+- [ ] Staff photo: endpoint `GET /staff-photo/{id}` (same streaming pattern as `/sponsor-logo/{id}` in Program.cs) + InputFile upload in admin staff dialog + `<img>` in `/hub/staff` card (fallback to AvatarEmoji)
+- [ ] Sponsor: ContactName/Phone fields in `/admin/sponsors` form + tap-to-call display in `/hub/sponsors` tile
+- [ ] Sponsor drag-and-drop sort in `/admin/sponsors` (HTML5 drag events via Blazor, saves SortOrder to DB via SponsorService.UpdateSortOrderAsync or similar)
+- [ ] Incident form (`HubSubNav.razor` modal): location dropdown from LocationService (active event locations) + "Other" option that reveals free-text; ReportType field shown only to Admin (default Internal for others)
+- [ ] `/hub/incidents` list + print view: show IncidentLocation name (or "Other: {text}") + ReportType badge
+- [ ] Schedule display (`/hub/schedule`): Travel renders as "Arrival/Departure"; Presentation events show PresenterName/PresenterBio; all times in `h:mm tt` 12-hour format
+- [ ] Schedule admin (`/admin/schedule`): Travel label; Presentation in event type dropdown; PresenterName/PresenterBio inputs conditional on EventType==Presentation; times display in 12-hour in table
+- [ ] Location images: endpoint `GET /location-image/{id}` in Program.cs + InputFile upload in `/admin/locations` + board space rendering in Board.razor and BoardDisplay.razor loads `Activity.Location` include and shows image
+- [ ] `/admin/activities` page: add Location dropdown (nullable, links activity to a Location for board image purposes)
+- [ ] Dashboard (`/dashboard`): new page with Sponsors widget (prominent), today's schedule widget, latest announcement widget, quick nav buttons; update `Index.razor` redirect from `/hub/schedule` → `/dashboard`
+- [ ] `/hub/incidents` role check: add `MedicalStaff` alongside `Admin` on the `[Authorize]` or inline role check
+- [ ] `/admin/users` role dropdown: add `Medical Staff` option
 
 **Next:** v1.0.0-rc — Dry Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 
 ---
 
-## Current State (as of 2026-06-02)
+## Current State (as of 2026-06-03)
 
-**Active branch:** `feature/118-v055-improvements` (off `dev`)
+**Active branch:** `feature/118-v055-improvements` (off `dev`) — ready to merge
 **Released to main:** v0.5.4 — schedule save bug fix
-**GitHub issue:** #118 — v0.5.5 scope (see below)
+**GitHub issue:** #118 — v0.5.5 scope (all items complete, pending PR)
 
 **v0.1.0 — Done:**
 - Blazor Server project: entities, repositories, services, SignalR hub, MudBlazor pages
@@ -97,7 +97,7 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - Fix: `HasForeignKey(e => e.CreatedBy)` added to `OnModelCreating`
 - Migration `FixScheduleEventCreatedByFK`: drops `CreatedByUserUserId` shadow column/index/FK; wires `CreatedBy` as the real FK to `Users.UserId`
 
-**v0.5.5 — In Progress (feature/118, issue #118):**
+**v0.5.5 — Done (feature/118, issue #118):**
 
 *Entities / enums changed:*
 - `Role` enum: add `MedicalStaff` (C# only — no schema change; stored via UserRole seed). Permissions: log transactions, view+acknowledge incident reports, all Hub features; no admin panel.
@@ -123,19 +123,19 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 - [x] SeedService: MedicalStaff UserRole + LogTransaction authority link; Mini Marios removed; board positions seed uses Group2/3/4
 - [x] Migration AddV055Enhancements created and applied to dev DB
 
-**v0.5.5 remaining (UI + service layer — pick up here next session):**
-- [ ] Staff photo: endpoint `GET /staff-photo/{id}` (same streaming pattern as `/sponsor-logo/{id}` in Program.cs) + InputFile upload in admin staff dialog + `<img>` in `/hub/staff` card (fallback to AvatarEmoji)
-- [ ] Sponsor: ContactName/Phone fields in `/admin/sponsors` form + tap-to-call display in `/hub/sponsors` tile
-- [ ] Sponsor drag-and-drop sort in `/admin/sponsors` (HTML5 drag events via Blazor, saves SortOrder to DB via SponsorService.UpdateSortOrderAsync or similar)
-- [ ] Incident form (`HubSubNav.razor` modal): location dropdown from LocationService (active event locations) + "Other" option that reveals free-text; ReportType field shown only to Admin (default Internal for others)
-- [ ] `/hub/incidents` list + print view: show IncidentLocation name (or "Other: {text}") + ReportType badge
-- [ ] Schedule display (`/hub/schedule`): Travel renders as "Arrival/Departure"; Presentation events show PresenterName/PresenterBio; all times in `h:mm tt` 12-hour format
-- [ ] Schedule admin (`/admin/schedule`): Travel label; Presentation in event type dropdown; PresenterName/PresenterBio inputs conditional on EventType==Presentation; times display in 12-hour in table
-- [ ] Location images: endpoint `GET /location-image/{id}` in Program.cs + InputFile upload in `/admin/locations` + board space rendering in Board.razor and BoardDisplay.razor loads `Activity.Location` include and shows image
-- [ ] `/admin/activities` page: add Location dropdown (nullable, links activity to a Location for board image purposes)
-- [ ] Dashboard (`/dashboard`): new page with Sponsors widget (prominent), today's schedule widget, latest announcement widget, quick nav buttons; update `Index.razor` redirect from `/hub/schedule` → `/dashboard`
-- [ ] `/hub/incidents` role check: add `MedicalStaff` alongside `Admin` on the `[Authorize]` or inline role check
-- [ ] `/admin/users` role dropdown: add `Medical Staff` option
+**v0.5.5 completed items:**
+- [x] Staff photo: endpoint `GET /staff-photo/{id}` + InputFile upload in admin staff dialog + `<img>` in `/hub/staff` card (fallback to AvatarEmoji)
+- [x] Sponsor: ContactName/Phone fields in `/admin/sponsors` form + tap-to-call display in `/hub/sponsors` tile
+- [x] Sponsor drag-and-drop sort in `/admin/sponsors` (HTML5 drag events; saves SortOrder to DB via `SponsorService.UpdateSortOrderAsync`)
+- [x] Incident form (`HubSubNav.razor` modal): location dropdown + "Other" free-text; Admin-only ReportType field
+- [x] `/hub/incidents` list + print view: IncidentLocation column + ReportType badge; MedicalStaff role access
+- [x] Schedule display (`/hub/schedule`): Travel → "Arrival/Departure"; Presentation type + PresenterName/Bio; 12-hr time format
+- [x] Schedule admin (`/admin/schedule`): same Travel label + Presentation type + conditional presenter fields + 12-hr times
+- [x] Location images: `GET /location-image/{id}` in Program.cs + InputFile upload in `/admin/locations` + board space shows location image when available
+- [x] `/admin/activities`: Location dropdown (nullable FK to Location for board image purposes)
+- [x] Dashboard (`/dashboard`): Sponsors widget, today's schedule, latest announcement, quick nav; `Index.razor` redirects here
+- [x] `/hub/incidents` + `/hub/incidents/{id}/print`: `MedicalStaff` role added alongside `Admin`
+- [x] `/admin/users` role dropdown: Medical Staff option added
 
 **Next:** v1.0.0-rc — Dry Run
 

--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -91,5 +91,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<InfoPage>()
             .HasIndex(p => p.Slug)
             .IsUnique();
+
+        // Activity → Location (optional): explicit FK to avoid shadow property bug
+        modelBuilder.Entity<Activity>()
+            .HasOne(a => a.Location)
+            .WithMany()
+            .HasForeignKey(a => a.LocationId)
+            .IsRequired(false);
+
+        // IncidentReport → Location (optional): explicit FK to avoid shadow property bug
+        modelBuilder.Entity<IncidentReport>()
+            .HasOne(r => r.IncidentLocation)
+            .WithMany()
+            .HasForeignKey(r => r.IncidentLocationId)
+            .IsRequired(false);
     }
 }

--- a/CampClotNot/Data/Entities/Activity.cs
+++ b/CampClotNot/Data/Entities/Activity.cs
@@ -5,11 +5,13 @@ public class Activity
     public Guid ActivityId { get; set; }
     public Guid EventId { get; set; }
     public Guid ActivityTypeId { get; set; }
+    public Guid? LocationId { get; set; }
     public string Name { get; set; } = "";
     public string Description { get; set; } = "";
 
     public Event Event { get; set; } = null!;
     public ActivityType ActivityType { get; set; } = null!;
+    public Location? Location { get; set; }
     public ICollection<BoardSpace> BoardSpaces { get; set; } = new List<BoardSpace>();
     public ICollection<ScriptedMiniGame> ScriptedMiniGames { get; set; } = new List<ScriptedMiniGame>();
 }

--- a/CampClotNot/Data/Entities/IncidentReport.cs
+++ b/CampClotNot/Data/Entities/IncidentReport.cs
@@ -10,6 +10,10 @@ public class IncidentReport
     public string PersonsInvolved { get; set; } = "";
     public string Description { get; set; } = "";
     public string RecommendedAction { get; set; } = "";
+    public Guid? IncidentLocationId { get; set; }
+    public Location? IncidentLocation { get; set; }
+    public string? IncidentLocationOther { get; set; }
+    public IncidentReportType ReportType { get; set; } = IncidentReportType.Internal;
     public Guid SubmittedByUserId { get; set; }
     public string SubmittedByName { get; set; } = "";
     public string SubmittedByRole { get; set; } = "";

--- a/CampClotNot/Data/Entities/Location.cs
+++ b/CampClotNot/Data/Entities/Location.cs
@@ -6,5 +6,7 @@ public class Location
     public string Name { get; set; } = "";
     public string? Description { get; set; }
     public int? Capacity { get; set; }
+    public byte[]? ImageData { get; set; }
+    public string? ImageContentType { get; set; }
     public int SortOrder { get; set; }
 }

--- a/CampClotNot/Data/Entities/ScheduleEvent.cs
+++ b/CampClotNot/Data/Entities/ScheduleEvent.cs
@@ -1,6 +1,6 @@
 namespace CampClotNot.Data.Entities;
 
-public enum ScheduleEventType { Activity, Meal, Travel, Free, Mandatory }
+public enum ScheduleEventType { Activity, Meal, Travel, Free, Mandatory, Presentation }
 
 public class ScheduleEvent
 {
@@ -15,6 +15,8 @@ public class ScheduleEvent
     public Guid? LocationId { get; set; }
     public Location? Location { get; set; }
     public ScheduleEventType EventType { get; set; }
+    public string? PresenterName { get; set; }
+    public string? PresenterBio { get; set; }
     public bool AppliesToAllGroups { get; set; } = true;
     public int? MaxCapacity { get; set; }       // stored silently; future registration feature
     public Guid CreatedBy { get; set; }

--- a/CampClotNot/Data/Entities/Sponsor.cs
+++ b/CampClotNot/Data/Entities/Sponsor.cs
@@ -10,5 +10,7 @@ public class Sponsor
     public byte[]? LogoData { get; set; }
     public string? LogoContentType { get; set; }
     public string? Website { get; set; }
+    public string? ContactName { get; set; }
+    public string? Phone { get; set; }
     public int SortOrder { get; set; }
 }

--- a/CampClotNot/Data/Entities/StaffMember.cs
+++ b/CampClotNot/Data/Entities/StaffMember.cs
@@ -9,6 +9,8 @@ public class StaffMember
     public string RoleTitle { get; set; } = "";
     public string? Phone { get; set; }
     public string? Email { get; set; }
+    public byte[]? PhotoData { get; set; }
+    public string? PhotoContentType { get; set; }
     public string AvatarEmoji { get; set; } = "👤";
     public bool IsVisible { get; set; } = true;
     public int SortOrder { get; set; }

--- a/CampClotNot/Data/Enums.cs
+++ b/CampClotNot/Data/Enums.cs
@@ -4,7 +4,9 @@ public enum Currency { Primary, Prestige }
 
 public enum AwardKind { Named, BigStick, Branch }
 
-public enum Role { Admin, Staff, Volunteer }
+public enum Role { Admin, Staff, MedicalStaff, Volunteer }
+
+public enum IncidentReportType { Internal = 0, ChildrensHarbor = 1 }
 
 public enum Feature { BoardGame, CoinShop, MiniGameSpinner, Announcements, Itinerary }
 

--- a/CampClotNot/Migrations/20260603051634_AddV055Enhancements.Designer.cs
+++ b/CampClotNot/Migrations/20260603051634_AddV055Enhancements.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603051634_AddV055Enhancements")]
+    partial class AddV055Enhancements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260603051634_AddV055Enhancements.cs
+++ b/CampClotNot/Migrations/20260603051634_AddV055Enhancements.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddV055Enhancements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PhotoContentType",
+                table: "StaffMembers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "PhotoData",
+                table: "StaffMembers",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactName",
+                table: "Sponsors",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Phone",
+                table: "Sponsors",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PresenterBio",
+                table: "ScheduleEvents",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PresenterName",
+                table: "ScheduleEvents",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ImageContentType",
+                table: "Locations",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "ImageData",
+                table: "Locations",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "IncidentLocationId",
+                table: "IncidentReports",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "IncidentLocationOther",
+                table: "IncidentReports",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReportType",
+                table: "IncidentReports",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "LocationId",
+                table: "Activities",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IncidentReports_IncidentLocationId",
+                table: "IncidentReports",
+                column: "IncidentLocationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Activities_LocationId",
+                table: "Activities",
+                column: "LocationId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Activities_Locations_LocationId",
+                table: "Activities",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_IncidentReports_Locations_IncidentLocationId",
+                table: "IncidentReports",
+                column: "IncidentLocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Activities_Locations_LocationId",
+                table: "Activities");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_IncidentReports_Locations_IncidentLocationId",
+                table: "IncidentReports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IncidentReports_IncidentLocationId",
+                table: "IncidentReports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Activities_LocationId",
+                table: "Activities");
+
+            migrationBuilder.DropColumn(
+                name: "PhotoContentType",
+                table: "StaffMembers");
+
+            migrationBuilder.DropColumn(
+                name: "PhotoData",
+                table: "StaffMembers");
+
+            migrationBuilder.DropColumn(
+                name: "ContactName",
+                table: "Sponsors");
+
+            migrationBuilder.DropColumn(
+                name: "Phone",
+                table: "Sponsors");
+
+            migrationBuilder.DropColumn(
+                name: "PresenterBio",
+                table: "ScheduleEvents");
+
+            migrationBuilder.DropColumn(
+                name: "PresenterName",
+                table: "ScheduleEvents");
+
+            migrationBuilder.DropColumn(
+                name: "ImageContentType",
+                table: "Locations");
+
+            migrationBuilder.DropColumn(
+                name: "ImageData",
+                table: "Locations");
+
+            migrationBuilder.DropColumn(
+                name: "IncidentLocationId",
+                table: "IncidentReports");
+
+            migrationBuilder.DropColumn(
+                name: "IncidentLocationOther",
+                table: "IncidentReports");
+
+            migrationBuilder.DropColumn(
+                name: "ReportType",
+                table: "IncidentReports");
+
+            migrationBuilder.DropColumn(
+                name: "LocationId",
+                table: "Activities");
+        }
+    }
+}

--- a/CampClotNot/Pages/Admin/Activities.razor
+++ b/CampClotNot/Pages/Admin/Activities.razor
@@ -1,6 +1,7 @@
 @page "/admin/activities"
 @attribute [Authorize(Roles = "Admin")]
 @inject MiniGameService MiniGameSvc
+@inject LocationService LocationSvc
 @inject ISnackbar Snackbar
 
 <PageTitle>Activities — Camp Clot Not</PageTitle>
@@ -23,10 +24,23 @@
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
 
-            <div style="margin-bottom:16px">
+            <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Description (optional)</div>
                 <input type="text" @bind="_fDescription" placeholder="Short description"
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:16px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Location (optional — used for board space image)</div>
+                <select value="@(_fLocationId?.ToString() ?? "")"
+                        @onchange="e => _fLocationId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : null"
+                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
+                    <option value="">— No location —</option>
+                    @foreach (var loc in _locations)
+                    {
+                        <option value="@loc.LocationId">@loc.Name</option>
+                    }
+                </select>
             </div>
 
             <div style="display:flex;gap:8px">
@@ -56,15 +70,18 @@
                             <tr style="background:var(--black)">
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Description</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Location</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                             </tr>
                         </thead>
                         <tbody>
                             @foreach (var a in _activities)
                             {
+                                var locName = a.LocationId.HasValue ? _locations.FirstOrDefault(l => l.LocationId == a.LocationId.Value)?.Name : null;
                                 <tr style="border-bottom:2px solid #E8E0CC">
                                     <td style="padding:10px 14px;font-size:13px;font-weight:700">@a.Name</td>
                                     <td style="padding:10px 14px;font-size:13px;color:var(--text-mid)">@(string.IsNullOrEmpty(a.Description) ? "—" : a.Description)</td>
+                                    <td style="padding:10px 14px;font-size:13px;color:var(--text-mid)">@(locName ?? "—")</td>
                                     <td style="padding:8px 10px">
                                         <div style="display:flex;gap:4px">
                                             <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(a)">Edit</button>
@@ -84,13 +101,16 @@
 
 @code {
     private List<Activity> _activities = new();
+    private List<Location> _locations = new();
     private bool _loading = true;
     private Guid _editingId;
     private string _fName = "";
     private string _fDescription = "";
+    private Guid? _fLocationId;
 
     protected override async Task OnInitializedAsync()
     {
+        _locations = await LocationSvc.GetAllAsync();
         await Reload();
         _loading = false;
     }
@@ -105,18 +125,19 @@
         _editingId    = a.ActivityId;
         _fName        = a.Name;
         _fDescription = a.Description;
+        _fLocationId  = a.LocationId;
     }
 
     private void CancelEdit()
     {
         _editingId = Guid.Empty;
-        _fName = ""; _fDescription = "";
+        _fName = ""; _fDescription = ""; _fLocationId = null;
     }
 
     private async Task SaveAsync()
     {
         if (string.IsNullOrWhiteSpace(_fName)) return;
-        await MiniGameSvc.UpsertActivityAsync(_editingId, SeedService.Id.EventCcn2026, _fName.Trim(), _fDescription.Trim());
+        await MiniGameSvc.UpsertActivityAsync(_editingId, SeedService.Id.EventCcn2026, _fName.Trim(), _fDescription.Trim(), _fLocationId);
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
         CancelEdit();
         await Reload();

--- a/CampClotNot/Pages/Admin/Locations.razor
+++ b/CampClotNot/Pages/Admin/Locations.razor
@@ -26,6 +26,23 @@
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
 
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Image (JPEG/PNG, max 2 MB)</div>
+                <InputFile OnChange="HandleImageUpload" accept="image/*" style="font-size:13px;font-family:'Nunito',sans-serif" />
+                @if (!string.IsNullOrWhiteSpace(_imageUploadError))
+                {
+                    <div style="color:#D12B2B;font-size:12px;margin-top:4px">@_imageUploadError</div>
+                }
+                @if (_fImageData is not null)
+                {
+                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">✅ File ready to upload</div>
+                }
+                else if (_currentHasImage)
+                {
+                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">Current: uploaded image (leave blank to keep)</div>
+                }
+            </div>
+
             <div style="display:flex;gap:10px;margin-bottom:16px">
                 <div style="flex:1">
                     <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Capacity</div>
@@ -107,6 +124,10 @@
     private string? _fDescription;
     private int? _fCapacity;
     private int _fSortOrder;
+    private byte[]? _fImageData;
+    private string? _fImageContentType;
+    private bool _currentHasImage;
+    private string _imageUploadError = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -121,17 +142,33 @@
 
     private void StartEdit(Location loc)
     {
-        _editingId    = loc.LocationId;
-        _fName        = loc.Name;
-        _fDescription = loc.Description;
-        _fCapacity    = loc.Capacity;
-        _fSortOrder   = loc.SortOrder;
+        _editingId       = loc.LocationId;
+        _fName           = loc.Name;
+        _fDescription    = loc.Description;
+        _fCapacity       = loc.Capacity;
+        _fSortOrder      = loc.SortOrder;
+        _fImageData      = null; _fImageContentType = null;
+        _currentHasImage = loc.ImageData is not null;
+        _imageUploadError = "";
     }
 
     private void CancelEdit()
     {
         _editingId = Guid.Empty;
         _fName = ""; _fDescription = null; _fCapacity = null; _fSortOrder = 0;
+        _fImageData = null; _fImageContentType = null; _currentHasImage = false; _imageUploadError = "";
+    }
+
+    private async Task HandleImageUpload(InputFileChangeEventArgs e)
+    {
+        _imageUploadError = "";
+        var file = e.File;
+        if (file.Size > 2 * 1024 * 1024) { _imageUploadError = "File too large — maximum 2 MB."; return; }
+        using var stream = file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        _fImageData = ms.ToArray();
+        _fImageContentType = file.ContentType;
     }
 
     private async Task SaveAsync()
@@ -139,11 +176,13 @@
         if (string.IsNullOrWhiteSpace(_fName)) return;
         await LocationSvc.UpsertAsync(new Location
         {
-            LocationId  = _editingId,
-            Name        = _fName.Trim(),
-            Description = _fDescription,
-            Capacity    = _fCapacity,
-            SortOrder   = _fSortOrder
+            LocationId        = _editingId,
+            Name              = _fName.Trim(),
+            Description       = _fDescription,
+            Capacity          = _fCapacity,
+            SortOrder         = _fSortOrder,
+            ImageData         = _fImageData,
+            ImageContentType  = _fImageContentType
         });
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
         CancelEdit();

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -54,10 +54,24 @@
                         style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
                     @foreach (var t in Enum.GetValues<ScheduleEventType>())
                     {
-                        <option value="@t">@t</option>
+                        <option value="@t">@DisplayEventType(t)</option>
                     }
                 </select>
             </div>
+
+            @if (_fType == ScheduleEventType.Presentation)
+            {
+                <div style="margin-bottom:14px">
+                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Presenter Name</div>
+                    <input type="text" @bind="_fPresenterName" placeholder="e.g. Dr. Jane Smith"
+                           style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                </div>
+                <div style="margin-bottom:14px">
+                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Presenter Bio (optional)</div>
+                    <textarea @bind="_fPresenterBio" rows="3" placeholder="Short bio shown to attendees"
+                              style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box;resize:vertical"></textarea>
+                </div>
+            }
 
             <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Location (optional)</div>
@@ -206,7 +220,7 @@
                                     </td>
                                     <td style="padding:8px 14px">
                                         <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
-                                            @ev.EventType
+                                            @DisplayEventType(ev.EventType)
                                         </span>
                                     </td>
                                     <td style="padding:8px 14px;font-size:12px;color:var(--text-mid)">@(ev.Location?.Name ?? "—")</td>
@@ -243,6 +257,8 @@
     private ScheduleEventType _fType = ScheduleEventType.Activity;
     private Guid? _fLocationId;
     private string? _fDesc;
+    private string? _fPresenterName;
+    private string? _fPresenterBio;
     private List<AssignmentFormRow> _fAssignments = new();
     private bool _assignmentsExpanded;
     private string _error = "";
@@ -289,14 +305,16 @@
 
     private void StartEdit(ScheduleEvent ev)
     {
-        _editingId   = ev.ScheduleEventId;
-        _fTitle      = ev.Title;
-        _fDesc       = ev.Description;
-        _fDateStr    = ev.CampDay.ToString("yyyy-MM-dd");
-        _fStartStr   = ev.StartTime.ToString("HH:mm");
-        _fEndStr     = ev.EndTime?.ToString("HH:mm") ?? "";
-        _fType       = ev.EventType;
-        _fLocationId = ev.LocationId;
+        _editingId      = ev.ScheduleEventId;
+        _fTitle         = ev.Title;
+        _fDesc          = ev.Description;
+        _fDateStr       = ev.CampDay.ToString("yyyy-MM-dd");
+        _fStartStr      = ev.StartTime.ToString("HH:mm");
+        _fEndStr        = ev.EndTime?.ToString("HH:mm") ?? "";
+        _fType          = ev.EventType;
+        _fLocationId    = ev.LocationId;
+        _fPresenterName = ev.PresenterName;
+        _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
         {
             var existing = ev.EventGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
@@ -322,6 +340,8 @@
         _fEndStr             = "";
         _fType               = ScheduleEventType.Activity;
         _fLocationId         = null;
+        _fPresenterName      = null;
+        _fPresenterBio       = null;
         _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
         _assignmentsExpanded = false;
         _error               = "";
@@ -343,6 +363,7 @@
             .Select(a => new GroupAssignmentDto(a.GroupId, a.ActivityId, a.LocationId, a.Note))
             .ToList();
 
+        var isPresentation = _fType == ScheduleEventType.Presentation;
         var dto = new ScheduleEventDto(
             _editingId,
             SeedService.Id.EventCcn2026,
@@ -350,7 +371,9 @@
             _fTitle.Trim(), _fDesc,
             _fLocationId, _fType,
             !assignments.Any(),
-            null, assignments
+            null, assignments,
+            isPresentation ? _fPresenterName : null,
+            isPresentation ? _fPresenterBio  : null
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fTitle} added." : $"{_fTitle} updated.", Severity.Success);
@@ -365,13 +388,20 @@
         await Reload();
     }
 
+    private static string DisplayEventType(ScheduleEventType t) => t switch
+    {
+        ScheduleEventType.Travel => "Arrival/Departure",
+        _ => t.ToString()
+    };
+
     private static string EventTypeBadgeColor(ScheduleEventType t) => t switch
     {
-        ScheduleEventType.Meal      => "#E67E22",
-        ScheduleEventType.Travel    => "#2980B9",
-        ScheduleEventType.Free      => "#27AE60",
-        ScheduleEventType.Mandatory => "#D12B2B",
-        _                           => "#8E44AD"
+        ScheduleEventType.Meal         => "#E67E22",
+        ScheduleEventType.Travel       => "#2980B9",
+        ScheduleEventType.Free         => "#27AE60",
+        ScheduleEventType.Mandatory    => "#D12B2B",
+        ScheduleEventType.Presentation => "#8E44AD",
+        _                              => "#8E44AD"
     };
 
     private class AssignmentFormRow

--- a/CampClotNot/Pages/Admin/Sponsors.razor
+++ b/CampClotNot/Pages/Admin/Sponsors.razor
@@ -50,6 +50,18 @@
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
 
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Contact Name (optional)</div>
+                <input type="text" @bind="_fContactName" placeholder="e.g. Jane Smith"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Phone (optional — tap-to-call)</div>
+                <input type="tel" @bind="_fPhone" placeholder="e.g. (205) 555-1234"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
             <div style="margin-bottom:16px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Sort Order</div>
                 <input type="number" @bind="_fSortOrder"
@@ -82,21 +94,31 @@
             }
             else
             {
+                <div style="font-size:11px;color:var(--text-light);margin-bottom:6px">Drag rows to reorder. Changes save immediately.</div>
                 <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
                         <thead>
                             <tr style="background:var(--black)">
+                                <th style="padding:10px 8px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left;width:28px"></th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Logo</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Website</th>
-                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Order</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                             </tr>
                         </thead>
                         <tbody>
-                            @foreach (var s in _sponsors)
+                            @for (int i = 0; i < _sponsors.Count; i++)
                             {
-                                <tr style="border-bottom:2px solid #E8E0CC">
+                                var s = _sponsors[i];
+                                var idx = i;
+                                <tr draggable="true"
+                                    style="border-bottom:2px solid #E8E0CC;background:@(_dragOverIndex == idx ? "#EDE7D0" : "transparent")"
+                                    @ondragstart="() => _dragIndex = idx"
+                                    @ondragover:preventDefault="true"
+                                    @ondragover="() => _dragOverIndex = idx"
+                                    @ondrop="() => DropAsync(idx)"
+                                    @ondragleave="() => { if (_dragOverIndex == idx) _dragOverIndex = -1; }">
+                                    <td style="padding:10px 8px;color:var(--text-light);cursor:grab;font-size:16px;text-align:center">⠿</td>
                                     <td style="padding:10px 14px;font-size:13px;font-weight:700">@s.Name</td>
                                     <td style="padding:8px 14px">
                                         <img src="@LogoSrc(s)" alt="@s.Name"
@@ -109,7 +131,6 @@
                                         }
                                         else { <span>—</span> }
                                     </td>
-                                    <td style="padding:10px 14px;font-size:13px">@s.SortOrder</td>
                                     <td style="padding:8px 10px">
                                         <div style="display:flex;gap:4px">
                                             <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(s)">Edit</button>
@@ -131,9 +152,13 @@
     private List<Sponsor> _sponsors = [];
     private bool _loading = true;
     private Guid _editingId;
+    private int _dragIndex = -1;
+    private int _dragOverIndex = -1;
     private string _fName = "";
     private string? _fLogoUrl;
     private string? _fWebsite;
+    private string? _fContactName;
+    private string? _fPhone;
     private int _fSortOrder;
     private byte[]? _fLogoData;
     private string? _fLogoContentType;
@@ -174,6 +199,8 @@
         _fName          = s.Name;
         _fLogoUrl       = s.LogoUrl;
         _fWebsite       = s.Website;
+        _fContactName   = s.ContactName;
+        _fPhone         = s.Phone;
         _fSortOrder     = s.SortOrder;
         _fLogoData      = null;
         _fLogoContentType = null;
@@ -185,7 +212,7 @@
     private void CancelEdit()
     {
         _editingId = Guid.Empty;
-        _fName = ""; _fLogoUrl = null; _fWebsite = null; _fSortOrder = 0;
+        _fName = ""; _fLogoUrl = null; _fWebsite = null; _fContactName = null; _fPhone = null; _fSortOrder = 0;
         _fLogoData = null; _fLogoContentType = null; _currentHasFile = false;
         _uploadError = ""; _saveError = "";
     }
@@ -212,6 +239,8 @@
             LogoData         = _fLogoData,
             LogoContentType  = _fLogoContentType,
             Website          = string.IsNullOrWhiteSpace(_fWebsite) ? null : _fWebsite.Trim(),
+            ContactName      = string.IsNullOrWhiteSpace(_fContactName) ? null : _fContactName.Trim(),
+            Phone            = string.IsNullOrWhiteSpace(_fPhone) ? null : _fPhone.Trim(),
             SortOrder        = _fSortOrder
         });
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
@@ -223,6 +252,18 @@
     {
         await SponsorSvc.DeleteAsync(s.SponsorId);
         Snackbar.Add($"{s.Name} deleted.", Severity.Info);
+        await Reload();
+    }
+
+    private async Task DropAsync(int dropIndex)
+    {
+        _dragOverIndex = -1;
+        if (_dragIndex < 0 || _dragIndex == dropIndex) { _dragIndex = -1; return; }
+        var item = _sponsors[_dragIndex];
+        _sponsors.RemoveAt(_dragIndex);
+        _sponsors.Insert(dropIndex, item);
+        _dragIndex = -1;
+        await SponsorSvc.UpdateSortOrderAsync(_sponsors);
         await Reload();
     }
 

--- a/CampClotNot/Pages/Admin/Users.razor
+++ b/CampClotNot/Pages/Admin/Users.razor
@@ -49,6 +49,7 @@
                         style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box;cursor:pointer">
                     <option value="Staff">Staff</option>
                     <option value="Volunteer">Volunteer / Counselor</option>
+                    <option value="MedicalStaff">Medical Staff</option>
                     <option value="Admin">Admin</option>
                 </select>
             </div>
@@ -165,6 +166,7 @@
                         style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box;cursor:pointer">
                     <option value="Staff">Staff</option>
                     <option value="Volunteer">Volunteer / Counselor</option>
+                    <option value="MedicalStaff">Medical Staff</option>
                     <option value="Admin">Admin</option>
                 </select>
             </div>

--- a/CampClotNot/Pages/Dashboard.razor
+++ b/CampClotNot/Pages/Dashboard.razor
@@ -1,13 +1,10 @@
 @page "/dashboard"
 @attribute [Authorize]
-@inject GroupService GroupSvc
-@inject TransactionService TxSvc
-@inject NavigationManager Nav
-@inject IDialogService DialogService
-@inject ThemeService ThemeSvc
-@implements IAsyncDisposable
+@inject SponsorService SponsorSvc
+@inject ScheduleService ScheduleSvc
+@inject AnnouncementService AnnouncementSvc
 
-<PageTitle>Dashboard — Camp Clot Not</PageTitle>
+<PageTitle>Home — Camp Clot Not</PageTitle>
 
 @if (_loading)
 {
@@ -17,235 +14,197 @@
 }
 else
 {
-    @* ── STANDINGS rank rows ── *@
-    <div class="ccn-section-label">🏆 Standings</div>
-    <div class="ccn-panel" style="margin-bottom:24px;overflow:hidden;animation:slideUp .3s ease">
-        @foreach (var entry in _ranked)
-        {
-            var rankClass = entry.Rank switch { 1 => "rank-1", 2 => "rank-2", 3 => "rank-3", _ => "rank-other" };
-            var rankBg    = entry.Rank switch
-            {
-                1 => "background:var(--color-primary)",
-                2 => "background:#E8E8E8",
-                3 => "background:#F5EED8",
-                _ => "background:var(--panel-bg)"
-            };
-            var medals = new[] { "🥇", "🥈", "🥉", "4️⃣" };
-            var medal  = entry.Rank <= medals.Length ? medals[entry.Rank - 1] : $"#{entry.Rank}";
-            var delay  = (entry.Rank - 1) * 60;
-            var initial = entry.Group.ShortName is { Length: > 0 } s ? s[..1] : "?";
+    @* ── HERO ── *@
+    <div style="position:relative;overflow:hidden;
+                background:#F5C800;
+                border:4px solid var(--black);border-radius:14px;
+                box-shadow:8px 8px 0 var(--black);
+                padding:32px 24px 28px;
+                margin-bottom:20px;
+                text-align:center;
+                animation:popIn .3s ease">
 
-            <div class="ccn-rank-row" style="@rankBg;animation:slideUp .3s ease @(delay)ms both">
+        @* Decorative background coins/stars *@
+        <img src="/img/ccn-coin.png" aria-hidden="true"
+             style="position:absolute;top:-8px;left:12px;width:54px;opacity:.18;transform:rotate(-20deg)" />
+        <img src="/img/ccn-star.png" aria-hidden="true"
+             style="position:absolute;bottom:6px;left:28px;width:44px;opacity:.18;transform:rotate(12deg)" />
+        <img src="/img/ccn-star.png" aria-hidden="true"
+             style="position:absolute;top:8px;right:18px;width:50px;opacity:.18;transform:rotate(-8deg)" />
+        <img src="/img/ccn-coin.png" aria-hidden="true"
+             style="position:absolute;bottom:-4px;right:24px;width:48px;opacity:.18;transform:rotate(25deg)" />
 
-                @* Rank medal *@
-                <div style="font-family:'Fredoka One',cursive;font-size:22px;width:36px;text-align:center;flex-shrink:0;color:var(--black)">
-                    @medal
-                </div>
+        @* Logo *@
+        <img src="/img/ccn-logo-2026.png" alt="Camp Clot Not Super Party '26"
+             style="height:72px;width:auto;object-fit:contain;margin-bottom:14px;
+                    filter:drop-shadow(2px 3px 0 rgba(0,0,0,.25))" />
 
-                @* Square avatar *@
-                <div style="@($"width:40px;height:40px;border-radius:50%;border:3px solid var(--black);background:{entry.Group.Color};display:flex;align-items:center;justify-content:center;font-family:'Fredoka One',cursive;font-size:16px;color:white;flex-shrink:0;box-shadow:2px 2px 0 var(--black);overflow:hidden")">
-                    @if (entry.Group.TokenAssetPath is not null)
-                    {
-                        <img src="@entry.Group.TokenAssetPath" style="width:100%;height:100%;object-fit:contain" />
-                    }
-                    else { @initial }
-                </div>
+        @* Welcome text *@
+        <div style="font-family:'Fredoka One',cursive;font-size:clamp(20px,5vw,28px);
+                    color:var(--black);line-height:1.15;margin-bottom:6px">
+            Welcome to Camp Clot Not
+        </div>
+        <div style="font-family:'Fredoka One',cursive;font-size:clamp(15px,4vw,20px);
+                    color:rgba(0,0,0,.65);line-height:1.2;margin-bottom:14px">
+            Super Party '26 &nbsp;·&nbsp; June 20–25
+        </div>
 
-                @* Name + board position *@
-                <div style="flex:1;min-width:0">
-                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black);
-                                white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
-                        @entry.Group.Name
-                    </div>
-                    @if (entry.Group.BoardPos is not null)
-                    {
-                        <div style="font-size:10px;color:var(--text-light);font-weight:700;margin-top:1px">
-                            Space @entry.Group.BoardPos.SpaceIndex
-                        </div>
-                    }
-                </div>
-
-                @* Score pills *@
-                <div style="display:flex;gap:6px;flex-shrink:0">
-                    <div style="display:flex;align-items:center;gap:5px;background:var(--color-accent);
-                                border:3px solid var(--black);border-radius:5px;padding:4px 10px;box-shadow:2px 2px 0 var(--black)">
-                        <img src="/img/ccn-coin.png" style="height:18px;width:auto" alt="coins" />
-                        <span style="font-family:'Fredoka One',cursive;font-size:17px;color:white">@entry.Coins</span>
-                    </div>
-                    <div style="display:flex;align-items:center;gap:5px;background:#2563C4;
-                                border:3px solid var(--black);border-radius:5px;padding:4px 10px;box-shadow:2px 2px 0 var(--black)">
-                        <img src="/img/ccn-star.png" style="height:18px;width:auto" alt="stars" />
-                        <span style="font-family:'Fredoka One',cursive;font-size:17px;color:white">@entry.Stars</span>
-                    </div>
-                </div>
-            </div>
-        }
+        @* Quick nav pills *@
+        <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:8px">
+            <a href="/leaderboard"      class="hero-pill">🏆 Leaderboard</a>
+            <a href="/hub/schedule"     class="hero-pill">📅 Schedule</a>
+            <a href="/hub/staff"        class="hero-pill">👥 Staff</a>
+            <a href="/hub/info"         class="hero-pill">📋 Camp Info</a>
+            <a href="/hub/announcements" class="hero-pill">🔔 Announcements</a>
+        </div>
     </div>
 
-    @* ── QUICK ACTIONS group cards ── *@
-    <div class="ccn-section-label">⚡ Quick Actions</div>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-bottom:24px">
-        @foreach (var entry in _ranked)
-        {
-            var delay   = (entry.Rank - 1) * 60;
-            var initial = entry.Group.ShortName is { Length: > 0 } sn ? sn[..1] : "?";
-            <div class="ccn-panel" style="padding:14px;border-top:5px solid @entry.Group.Color;animation:slideUp .3s ease @(delay)ms both">
-
-                <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
-                    <div style="@($"width:40px;height:40px;border-radius:50%;border:3px solid var(--black);background:{entry.Group.Color};display:flex;align-items:center;justify-content:center;font-family:'Fredoka One',cursive;font-size:16px;color:white;flex-shrink:0;box-shadow:2px 2px 0 var(--black);overflow:hidden")">
-                        @if (entry.Group.TokenAssetPath is not null)
-                        {
-                            <img src="@entry.Group.TokenAssetPath" style="width:100%;height:100%;object-fit:contain" />
-                        }
-                        else { @initial }
-                    </div>
-                    <div>
-                        <div style="font-family:'Fredoka One',cursive;font-size:14px;color:var(--black)">@entry.Group.Name</div>
-                        @if (entry.Group.BoardPos is not null)
-                        {
-                            <div style="font-size:10px;color:var(--text-light);font-weight:700;margin-top:1px">
-                                Space @entry.Group.BoardPos.SpaceIndex
-                            </div>
-                        }
-                    </div>
-                </div>
-
-                <div style="display:flex;gap:10px;margin-bottom:12px">
-                    <div style="flex:1;border:3px solid var(--black);border-radius:7px;border-top:4px solid var(--color-primary);padding:8px 12px;text-align:center;box-shadow:2px 2px 0 var(--black)">
-                        <div style="font-family:'Fredoka One',cursive;font-size:28px;line-height:1;color:var(--black)">@entry.Coins</div>
-                        <div style="display:flex;align-items:center;justify-content:center;gap:4px;margin-top:3px">
-                            <img src="/img/ccn-coin.png" style="height:12px;width:auto" alt="coins" />
-                            <span style="font-size:9px;font-weight:800;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-mid)">Coins</span>
-                        </div>
-                    </div>
-                    <div style="flex:1;border:3px solid var(--black);border-radius:7px;border-top:4px solid var(--color-accent);padding:8px 12px;text-align:center;box-shadow:2px 2px 0 var(--black)">
-                        <div style="font-family:'Fredoka One',cursive;font-size:28px;line-height:1;color:var(--black)">@entry.Stars</div>
-                        <div style="display:flex;align-items:center;justify-content:center;gap:4px;margin-top:3px">
-                            <img src="/img/ccn-star.png" style="height:12px;width:auto" alt="stars" />
-                            <span style="font-size:9px;font-weight:800;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-mid)">Stars</span>
-                        </div>
-                    </div>
-                </div>
-
-                <div style="display:flex;gap:8px">
-                    <button class="ccn-btn" style="flex:1;background:var(--color-primary);font-size:12px;padding:6px 10px"
-                            @onclick="@(() => OpenTransactionDialog(entry.Group.GroupId, Currency.Primary))">
-                        + Coins
-                    </button>
-                    <button class="ccn-btn" style="flex:1;background:var(--color-accent);color:white;font-size:12px;padding:6px 10px"
-                            @onclick="@(() => OpenTransactionDialog(entry.Group.GroupId, Currency.Prestige))">
-                        + Stars
-                    </button>
-                </div>
-            </div>
-        }
-    </div>
-
-    @* ── RECENT ACTIVITY ── *@
-    @if (_recentTransactions.Any())
+    @* ── SPONSORS ── *@
+    @if (_sponsors.Any())
     {
-        <div class="ccn-section-label">🕐 Recent Activity</div>
-        <div class="ccn-panel" style="overflow:hidden;margin-bottom:80px">
-            @for (int i = 0; i < _recentTransactions.Count; i++)
-            {
-                var tx        = _recentTransactions[i];
-                var isPrimary = tx.CurrencyType?.SystemName == nameof(Currency.Primary);
-                var sep       = i < _recentTransactions.Count - 1 ? "border-bottom:2px solid #E8E0CC" : "";
-
-                <div style="display:flex;align-items:center;gap:12px;padding:12px 14px;@sep">
-                    <div style="@($"width:36px;height:36px;border-radius:6px;border:2px solid var(--black);background:{(isPrimary ? "var(--color-primary)" : "var(--color-accent)")};display:flex;align-items:center;justify-content:center;flex-shrink:0;box-shadow:2px 2px 0 var(--black)")">
-                        <img src="@(isPrimary ? "/img/ccn-coin.png" : "/img/ccn-star.png")" style="height:22px;width:auto" alt="@(isPrimary ? "coin" : "star")" />
-                    </div>
-                    <div style="flex:1;min-width:0">
-                        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-                            <span style="@($"font-family:'Fredoka One',cursive;font-size:13px;color:{tx.Group?.Color ?? "var(--black)"}")">@tx.Group?.Name</span>
-                            <span style="font-weight:800;font-size:13px;color:@(tx.Amount > 0 ? "var(--color-success)" : "var(--color-accent)")">
-                                @(tx.Amount > 0 ? "+" : "")@tx.Amount @(isPrimary ? "coins" : "stars")
-                            </span>
-                        </div>
-                        <div style="font-size:10px;color:var(--text-light);margin-top:2px;font-weight:700">
-                            @(tx.Note != null ? $"{tx.Note} · " : "")@tx.LoggedBy · @tx.CreatedAt.ToLocalTime().ToString("h:mm tt")
-                        </div>
-                    </div>
-                </div>
-            }
+        <div class="ccn-panel" style="margin-bottom:18px;padding:18px 20px;animation:slideUp .25s ease">
+            <div style="font-family:'Fredoka One',cursive;font-size:16px;color:var(--black);margin-bottom:14px;
+                        display:flex;align-items:center;justify-content:space-between">
+                <span>🏆 Our Sponsors</span>
+                <a href="/hub/sponsors" style="font-size:11px;color:var(--color-primary);text-decoration:none">View all →</a>
+            </div>
+            <div style="display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:center">
+                @foreach (var s in _sponsors.Take(8))
+                {
+                    @if (!string.IsNullOrWhiteSpace(s.Website))
+                    {
+                        <a href="@s.Website" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+                            <img src="@SponsorLogoSrc(s)" alt="@s.Name"
+                                 style="height:52px;width:auto;max-width:130px;object-fit:contain;
+                                        background:white;border:2px solid #D8D0BC;border-radius:8px;padding:5px 8px;
+                                        transition:opacity .15s"
+                                 onmouseover="this.style.opacity='.75'" onmouseout="this.style.opacity='1'" />
+                        </a>
+                    }
+                    else
+                    {
+                        <img src="@SponsorLogoSrc(s)" alt="@s.Name"
+                             style="height:52px;width:auto;max-width:130px;object-fit:contain;
+                                    background:white;border:2px solid #D8D0BC;border-radius:8px;padding:5px 8px" />
+                    }
+                }
+            </div>
         </div>
     }
+
+    @* ── TODAY + ANNOUNCEMENT ── *@
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-bottom:6px">
+
+        @* Today's Schedule *@
+        <div class="ccn-panel" style="padding:18px;animation:slideUp .3s ease;border-top:5px solid #2980B9">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+                <div style="font-family:'Fredoka One',cursive;font-size:16px;color:var(--black)">📅 Today's Schedule</div>
+                <a href="/hub/schedule" style="font-size:11px;font-family:'Fredoka One',cursive;
+                                               color:#2980B9;text-decoration:none">Full →</a>
+            </div>
+            @if (!_todayEvents.Any())
+            {
+                <p style="font-size:13px;color:var(--text-light);margin:0;font-style:italic">Nothing on the schedule today.</p>
+            }
+            else
+            {
+                @foreach (var ev in _todayEvents.Take(5))
+                {
+                    <div style="display:flex;gap:10px;align-items:baseline;padding:6px 0;border-bottom:1px solid #E8E0CC">
+                        <span style="font-size:11px;color:var(--text-light);white-space:nowrap;min-width:58px;font-weight:700">
+                            @ev.StartTime.ToString("h:mm tt")
+                        </span>
+                        <span style="font-size:13px;font-weight:700;color:var(--black)">@ev.Title</span>
+                    </div>
+                }
+                @if (_todayEvents.Count > 5)
+                {
+                    <div style="font-size:11px;color:var(--text-light);padding-top:6px;font-style:italic">
+                        +@(_todayEvents.Count - 5) more — <a href="/hub/schedule" style="color:var(--color-primary)">see full schedule</a>
+                    </div>
+                }
+            }
+        </div>
+
+        @* Latest Announcement *@
+        @if (_latestAnnouncement is not null)
+        {
+            var urgentBorder = _latestAnnouncement.Priority == AnnouncementPriority.Urgent
+                ? "border-top:5px solid #D12B2B"
+                : "border-top:5px solid #E67E22";
+            <div class="ccn-panel" style="padding:18px;animation:slideUp .35s ease;@urgentBorder">
+                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+                    <div style="font-family:'Fredoka One',cursive;font-size:16px;color:var(--black)">
+                        @(_latestAnnouncement.Priority == AnnouncementPriority.Urgent ? "🚨" : "📣") Latest News
+                    </div>
+                    <a href="/hub/announcements" style="font-size:11px;font-family:'Fredoka One',cursive;
+                                                        color:#E67E22;text-decoration:none">All →</a>
+                </div>
+                @if (_latestAnnouncement.Priority == AnnouncementPriority.Urgent)
+                {
+                    <span style="font-size:10px;font-weight:800;letter-spacing:1px;text-transform:uppercase;
+                                 color:white;background:#D12B2B;padding:2px 8px;border-radius:4px;border:2px solid var(--black);
+                                 display:inline-block;margin-bottom:8px">URGENT</span>
+                }
+                <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black);margin-bottom:6px">
+                    @_latestAnnouncement.Title
+                </div>
+                <div style="font-size:12px;color:var(--text-mid);line-height:1.5;
+                             overflow:hidden;display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical">
+                    @_latestAnnouncement.Body
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="ccn-panel" style="padding:18px;animation:slideUp .35s ease;border-top:5px solid #E67E22;
+                                          display:flex;flex-direction:column;align-items:center;justify-content:center;
+                                          text-align:center;gap:10px">
+                <div style="font-size:36px">📣</div>
+                <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">No announcements yet</div>
+                <a href="/hub/announcements" class="ccn-btn" style="font-size:12px;padding:7px 18px">View Board</a>
+            </div>
+        }
+
+    </div>
 }
 
-@* ── Log Score FAB ── *@
-<button class="ccn-btn ccn-fab-mobile" style="position:fixed;bottom:24px;right:24px;background:var(--color-accent);color:white;
-                                font-size:15px;padding:13px 24px;border-radius:50px;border-color:var(--black);
-                                box-shadow:4px 4px 0 var(--black);z-index:50;
-                                display:flex;align-items:center;gap:8px"
-        @onclick="OpenTransactionDialog">
-    ＋ Log Score
-</button>
-
-<LogTransactionDialog @ref="_txDialog" OnTransactionPosted="RefreshAsync" />
+<style>
+    .hero-pill {
+        font-family: 'Fredoka One', cursive;
+        font-size: 13px;
+        padding: 6px 16px;
+        background: rgba(0,0,0,.22);
+        border: 2.5px solid rgba(0,0,0,.5);
+        border-radius: 50px;
+        color: var(--black);
+        text-decoration: none;
+        transition: background .15s, transform .1s;
+        display: inline-block;
+    }
+    .hero-pill:hover  { background: rgba(0,0,0,.22); transform: translateY(-1px); }
+    .hero-pill:active { background: rgba(0,0,0,.30); transform: scale(.96); }
+</style>
 
 @code {
-    private List<GroupEntry>   _ranked             = new();
-    private List<Transaction>  _recentTransactions = new();
-    private bool               _loading            = true;
-    private LogTransactionDialog _txDialog         = null!;
-    private HubConnection?     _hub;
+    private List<Sponsor>       _sponsors           = new();
+    private List<ScheduleEvent> _todayEvents        = new();
+    private Announcement?       _latestAnnouncement;
+    private bool                _loading            = true;
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshAsync();
+        _sponsors = await SponsorSvc.GetAllForEventAsync(SeedService.Id.EventCcn2026);
+
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        _todayEvents = await ScheduleSvc.GetForDayAsync(SeedService.Id.EventCcn2026, today);
+
+        var feed = await AnnouncementSvc.GetFeedAsync();
+        _latestAnnouncement = feed.FirstOrDefault();
+
         _loading = false;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (!firstRender) return;
-
-        _hub = new HubConnectionBuilder()
-            .WithUrl(Nav.ToAbsoluteUri("/livehub"))
-            .WithAutomaticReconnect()
-            .Build();
-
-        _hub.On("ScoresUpdated", async () =>
-        {
-            await RefreshAsync();
-            await InvokeAsync(StateHasChanged);
-        });
-
-        await _hub.StartAsync();
-    }
-
-    private async Task RefreshAsync()
-    {
-        var groups  = await GroupSvc.GetAllAsync();
-        var entries = new List<GroupEntry>();
-        foreach (var g in groups)
-        {
-            var coins = await GroupSvc.GetTotalAsync(g.GroupId, Currency.Primary);
-            var stars = await GroupSvc.GetTotalAsync(g.GroupId, Currency.Prestige);
-            entries.Add(new GroupEntry(g, coins, stars));
-        }
-        _ranked = entries
-            .OrderByDescending(e => e.Stars)
-            .ThenByDescending(e => e.Coins)
-            .Select((e, i) => e with { Rank = i + 1 })
-            .ToList();
-
-        var allTx = await TxSvc.GetAllAsync();
-        _recentTransactions = allTx.Where(t => t.VoidedAt == null).Take(5).ToList();
-    }
-
-    private async Task OpenTransactionDialog() => await _txDialog.OpenAsync();
-
-    private async Task OpenTransactionDialog(Guid groupId, Currency currency)
-    {
-        await _txDialog.OpenAsync(groupId, currency);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_hub is not null) await _hub.DisposeAsync();
-    }
-
-    private record GroupEntry(Group Group, int Coins, int Stars, int Rank = 0);
+    private static string SponsorLogoSrc(Sponsor s) =>
+        s.LogoData is not null ? $"/sponsors/logo/{s.SponsorId}" : (s.LogoUrl ?? "");
 }

--- a/CampClotNot/Pages/Hub/HubSubNav.razor
+++ b/CampClotNot/Pages/Hub/HubSubNav.razor
@@ -144,11 +144,41 @@
                           placeholder="Include what led up to and responses to the incident"></textarea>
             </div>
 
-            <div style="margin-bottom:20px">
+            <div style="margin-bottom:14px">
                 <div class="incident-field-label">Recommended Action</div>
                 <textarea class="incident-input" rows="3" @bind="_fRecommendedAction"
                           placeholder="Optional"></textarea>
             </div>
+
+            <div style="margin-bottom:14px">
+                <div class="incident-field-label">Location</div>
+                <select class="incident-input"
+                        value="@_fLocationSelection"
+                        @onchange="e => HandleLocationChange(e.Value?.ToString())">
+                    <option value="">— Select location —</option>
+                    @foreach (var loc in _locations)
+                    {
+                        <option value="@loc.LocationId">@loc.Name</option>
+                    }
+                    <option value="other">Other</option>
+                </select>
+                @if (_showOtherLocation)
+                {
+                    <input type="text" class="incident-input" style="margin-top:8px"
+                           @bind="_fLocationOther" placeholder="Describe location" />
+                }
+            </div>
+
+            @if (_isAdmin)
+            {
+                <div style="margin-bottom:14px">
+                    <div class="incident-field-label">Report Type</div>
+                    <select class="incident-input" @bind="_fReportType">
+                        <option value="@IncidentReportType.Internal">Internal</option>
+                        <option value="@IncidentReportType.ChildrensHarbor">Children's Harbor</option>
+                    </select>
+                </div>
+            }
 
             @if (!string.IsNullOrWhiteSpace(_errorMsg))
             {
@@ -182,10 +212,25 @@
     private string _fPersonsInvolved    = "";
     private string _fDescription        = "";
     private string _fRecommendedAction  = "";
+    private string _fLocationSelection  = "";
+    private Guid? _fLocationId;
+    private string? _fLocationOther;
+    private bool _showOtherLocation;
+    private IncidentReportType _fReportType = IncidentReportType.Internal;
+    private bool _isAdmin;
+    private List<Location> _locations = [];
 
     // Injected via parameter from parent — avoids cascading inject issues in component tree
     [Inject] private IncidentReportService IncidentSvc { get; set; } = default!;
+    [Inject] private LocationService LocationSvc { get; set; } = default!;
     [Inject] private ISnackbar Snackbar { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var state = await Auth.GetAuthenticationStateAsync();
+        _isAdmin = state.User.IsInRole("Admin");
+        _locations = await LocationSvc.GetAllAsync();
+    }
 
     private void OpenModal()
     {
@@ -194,8 +239,29 @@
         _fPersonsInvolved  = "";
         _fDescription      = "";
         _fRecommendedAction = "";
+        _fLocationSelection = "";
+        _fLocationId        = null;
+        _fLocationOther     = null;
+        _showOtherLocation  = false;
+        _fReportType        = IncidentReportType.Internal;
         _errorMsg          = "";
         _modalOpen         = true;
+    }
+
+    private void HandleLocationChange(string? value)
+    {
+        _fLocationSelection = value ?? "";
+        if (string.IsNullOrEmpty(value) || value == "other")
+        {
+            _fLocationId = null;
+            _showOtherLocation = value == "other";
+        }
+        else if (Guid.TryParse(value, out var id))
+        {
+            _fLocationId = id;
+            _showOtherLocation = false;
+            _fLocationOther = null;
+        }
     }
 
     private void CloseModal() => _modalOpen = false;
@@ -219,15 +285,18 @@
 
         await IncidentSvc.SubmitAsync(new IncidentReport
         {
-            EventId            = Services.SeedService.Id.EventCcn2026,
-            DateOfIncident     = _fDateOfIncident,
-            DateCompleted      = _fDateCompleted,
-            PersonsInvolved    = _fPersonsInvolved.Trim(),
-            Description        = _fDescription.Trim(),
-            RecommendedAction  = _fRecommendedAction.Trim(),
-            SubmittedByUserId  = userId,
-            SubmittedByName    = name,
-            SubmittedByRole    = role,
+            EventId                = Services.SeedService.Id.EventCcn2026,
+            DateOfIncident         = _fDateOfIncident,
+            DateCompleted          = _fDateCompleted,
+            PersonsInvolved        = _fPersonsInvolved.Trim(),
+            Description            = _fDescription.Trim(),
+            RecommendedAction      = _fRecommendedAction.Trim(),
+            SubmittedByUserId      = userId,
+            SubmittedByName        = name,
+            SubmittedByRole        = role,
+            IncidentLocationId     = _fLocationId,
+            IncidentLocationOther  = _showOtherLocation ? _fLocationOther?.Trim() : null,
+            ReportType             = _isAdmin ? _fReportType : IncidentReportType.Internal,
         });
 
         _submitting = false;

--- a/CampClotNot/Pages/Hub/IncidentPrint.razor
+++ b/CampClotNot/Pages/Hub/IncidentPrint.razor
@@ -1,6 +1,6 @@
 @page "/hub/incidents/{Id:guid}/print"
 @layout PrintLayout
-@attribute [Authorize(Roles = "Admin")]
+@attribute [Authorize(Roles = "Admin,MedicalStaff")]
 @inject IncidentReportService IncidentSvc
 
 <PageTitle>Incident Report — Camp Clot Not</PageTitle>
@@ -96,7 +96,17 @@ else
     <div class="print-page">
         <div class="print-header">
             <div style="width:80px"></div>
-            <h1 class="print-title">INCIDENT REPORT FORM</h1>
+            <div style="flex:1;text-align:center">
+                <h1 class="print-title" style="margin-bottom:6px">INCIDENT REPORT FORM</h1>
+                @if (_report.ReportType == IncidentReportType.ChildrensHarbor)
+                {
+                    <span style="background:#2980B9;color:white;padding:3px 10px;border-radius:4px;font-size:12px;font-weight:700;letter-spacing:1px">CHILDREN'S HARBOR</span>
+                }
+                else
+                {
+                    <span style="background:#888;color:white;padding:3px 10px;border-radius:4px;font-size:12px;font-weight:700;letter-spacing:1px">INTERNAL</span>
+                }
+            </div>
             <img src="/img/childrens-harbor-logo.png" alt="Children's Harbor" class="print-logo" />
         </div>
 
@@ -114,6 +124,11 @@ else
         <div class="print-field">
             <div class="print-label">Persons Involved</div>
             <div class="print-value">@_report.PersonsInvolved</div>
+        </div>
+
+        <div class="print-field">
+            <div class="print-label">Location</div>
+            <div class="print-value">@(_report.IncidentLocation?.Name ?? (_report.IncidentLocationOther is not null ? $"Other: {_report.IncidentLocationOther}" : "—"))</div>
         </div>
 
         <div class="print-field">

--- a/CampClotNot/Pages/Hub/Incidents.razor
+++ b/CampClotNot/Pages/Hub/Incidents.razor
@@ -1,5 +1,5 @@
 @page "/hub/incidents"
-@attribute [Authorize(Roles = "Admin")]
+@attribute [Authorize(Roles = "Admin,MedicalStaff")]
 @inject IncidentReportService IncidentSvc
 @inject AuthenticationStateProvider Auth
 @inject ISnackbar Snackbar
@@ -28,6 +28,8 @@
                         <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Date</th>
                         <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Submitted By</th>
                         <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Persons Involved</th>
+                        <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Location</th>
+                        <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Type</th>
                         <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Status</th>
                         <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                     </tr>
@@ -43,8 +45,21 @@
                                 @r.SubmittedByName<br />
                                 <span style="font-size:11px;color:var(--text-light)">@r.SubmittedByRole</span>
                             </td>
-                            <td style="padding:10px 14px;font-size:13px;max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
-                                @(r.PersonsInvolved.Length > 60 ? r.PersonsInvolved[..60] + "…" : r.PersonsInvolved)
+                            <td style="padding:10px 14px;font-size:13px;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+                                @(r.PersonsInvolved.Length > 50 ? r.PersonsInvolved[..50] + "…" : r.PersonsInvolved)
+                            </td>
+                            <td style="padding:10px 14px;font-size:12px;color:var(--text-mid);white-space:nowrap">
+                                @(r.IncidentLocation?.Name ?? (r.IncidentLocationOther is not null ? $"Other: {r.IncidentLocationOther}" : "—"))
+                            </td>
+                            <td style="padding:10px 14px;font-size:11px;white-space:nowrap">
+                                @if (r.ReportType == IncidentReportType.ChildrensHarbor)
+                                {
+                                    <span style="background:#2980B9;color:white;padding:2px 7px;border-radius:4px;font-weight:700">CH</span>
+                                }
+                                else
+                                {
+                                    <span style="background:#888;color:white;padding:2px 7px;border-radius:4px;font-weight:700">INT</span>
+                                }
                             </td>
                             <td style="padding:10px 14px;font-size:12px">
                                 @if (r.IsAcknowledged)

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -143,8 +143,20 @@
                                 }
 
                                 <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
-                                    @ev.EventType
+                                    @DisplayEventType(ev.EventType)
                                 </span>
+
+                                @if (ev.EventType == ScheduleEventType.Presentation && ev.PresenterName is not null)
+                                {
+                                    <div style="font-size:13px;margin-top:4px;color:var(--text-mid)">🎤 @ev.PresenterName</div>
+                                    @if (ev.PresenterBio is not null)
+                                    {
+                                        <details style="margin-top:4px">
+                                            <summary style="font-size:12px;color:var(--text-light);cursor:pointer;font-family:'Fredoka One',cursive">About the speaker</summary>
+                                            <div style="font-size:13px;margin-top:4px;color:var(--text-mid)">@ev.PresenterBio</div>
+                                        </details>
+                                    }
+                                }
 
                                 @if (_isAdminOrStaff && ev.EventGroups.Any())
                                 {
@@ -202,9 +214,14 @@
             <MudSelect @bind-Value="_fType"        Label="Event Type" Class="mb-3">
                 @foreach (var t in Enum.GetValues<ScheduleEventType>())
                 {
-                    <MudSelectItem Value="@t">@t</MudSelectItem>
+                    <MudSelectItem Value="@t">@DisplayEventType(t)</MudSelectItem>
                 }
             </MudSelect>
+            @if (_fType == ScheduleEventType.Presentation)
+            {
+                <MudTextField @bind-Value="_fPresenterName" Label="Presenter Name" Class="mb-3" />
+                <MudTextField @bind-Value="_fPresenterBio"  Label="Presenter Bio (optional)" Lines="3" Class="mb-3" />
+            }
             <MudTextField @bind-Value="_fDesc"     Label="Description (optional)" Lines="2" Class="mb-3" />
 
             <MudSelect @bind-Value="_fLocationId" Label="Location (optional)" Class="mb-3" Clearable="true">
@@ -306,6 +323,8 @@
     private TimeSpan? _fEnd;
     private ScheduleEventType _fType = ScheduleEventType.Activity;
     private Guid? _fLocationId;
+    private string? _fPresenterName;
+    private string? _fPresenterBio;
     private List<AssignmentFormRow> _fAssignments = new();
     private bool _assignmentsExpanded;
 
@@ -370,12 +389,13 @@
 
     private void OpenAddForm()
     {
-        _editingId   = Guid.Empty;
-        _fTitle      = ""; _fDesc = null;
-        _fDate       = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
-        _fStart      = new TimeSpan(9, 0, 0); _fEnd = null;
-        _fType       = ScheduleEventType.Activity;
-        _fLocationId = null;
+        _editingId      = Guid.Empty;
+        _fTitle         = ""; _fDesc = null;
+        _fDate          = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
+        _fStart         = new TimeSpan(9, 0, 0); _fEnd = null;
+        _fType          = ScheduleEventType.Activity;
+        _fLocationId    = null;
+        _fPresenterName = null; _fPresenterBio = null;
         _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
         _assignmentsExpanded = false;
         _showForm            = true;
@@ -383,14 +403,16 @@
 
     private void OpenEditForm(ScheduleEvent ev)
     {
-        _editingId   = ev.ScheduleEventId;
-        _fTitle      = ev.Title;
-        _fDesc       = ev.Description;
-        _fDate       = ev.CampDay.ToDateTime(TimeOnly.MinValue);
-        _fStart      = ev.StartTime.ToTimeSpan();
-        _fEnd        = ev.EndTime?.ToTimeSpan();
-        _fType       = ev.EventType;
-        _fLocationId = ev.LocationId;
+        _editingId      = ev.ScheduleEventId;
+        _fTitle         = ev.Title;
+        _fDesc          = ev.Description;
+        _fDate          = ev.CampDay.ToDateTime(TimeOnly.MinValue);
+        _fStart         = ev.StartTime.ToTimeSpan();
+        _fEnd           = ev.EndTime?.ToTimeSpan();
+        _fType          = ev.EventType;
+        _fLocationId    = ev.LocationId;
+        _fPresenterName = ev.PresenterName;
+        _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
         {
             var existing = ev.EventGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
@@ -417,6 +439,7 @@
             .Select(a => new GroupAssignmentDto(a.GroupId, a.ActivityId, a.LocationId, a.Note))
             .ToList();
 
+        var isPresentation = _fType == ScheduleEventType.Presentation;
         var dto = new ScheduleEventDto(
             _editingId,
             SeedService.Id.EventCcn2026,
@@ -425,7 +448,9 @@
             _fEnd.HasValue ? TimeOnly.FromTimeSpan(_fEnd.Value) : null,
             _fTitle, _fDesc, _fLocationId, _fType,
             !assignments.Any(),
-            null, assignments
+            null, assignments,
+            isPresentation ? _fPresenterName : null,
+            isPresentation ? _fPresenterBio  : null
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
 
@@ -441,13 +466,20 @@
         await LoadEvents();
     }
 
+    private static string DisplayEventType(ScheduleEventType t) => t switch
+    {
+        ScheduleEventType.Travel => "Arrival/Departure",
+        _ => t.ToString()
+    };
+
     private static string EventTypeBadgeColor(ScheduleEventType t) => t switch
     {
-        ScheduleEventType.Meal      => "#E67E22",
-        ScheduleEventType.Travel    => "#2980B9",
-        ScheduleEventType.Free      => "#27AE60",
-        ScheduleEventType.Mandatory => "#D12B2B",
-        _                           => "#8E44AD"
+        ScheduleEventType.Meal         => "#E67E22",
+        ScheduleEventType.Travel       => "#2980B9",
+        ScheduleEventType.Free         => "#27AE60",
+        ScheduleEventType.Mandatory    => "#D12B2B",
+        ScheduleEventType.Presentation => "#8E44AD",
+        _                              => "#8E44AD"
     };
 
     private class AssignmentFormRow

--- a/CampClotNot/Pages/Hub/Sponsors.razor
+++ b/CampClotNot/Pages/Hub/Sponsors.razor
@@ -22,22 +22,27 @@
         <div style="display:flex;flex-wrap:wrap;gap:16px">
             @foreach (var s in _sponsors)
             {
-                @if (!string.IsNullOrWhiteSpace(s.Website))
-                {
-                    <a href="@s.Website" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
-                        <div class="sponsor-tile">
+                <div class="sponsor-tile">
+                    @if (!string.IsNullOrWhiteSpace(s.Website))
+                    {
+                        <a href="@s.Website" target="_blank" rel="noopener noreferrer" class="sponsor-logo-link">
                             <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
-                            <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
-                        </div>
-                    </a>
-                }
-                else
-                {
-                    <div class="sponsor-tile">
+                        </a>
+                    }
+                    else
+                    {
                         <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
-                        <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
-                    </div>
-                }
+                    }
+                    <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
+                    @if (!string.IsNullOrEmpty(s.ContactName))
+                    {
+                        <div style="font-size:.8rem;color:var(--text-light);text-align:center">@s.ContactName</div>
+                    }
+                    @if (!string.IsNullOrEmpty(s.Phone))
+                    {
+                        <a href="tel:@s.Phone" style="font-size:.85rem;font-weight:700;color:var(--color-primary);text-decoration:none;text-align:center;display:block">@s.Phone</a>
+                    }
+                </div>
             }
         </div>
     }
@@ -54,15 +59,14 @@
         flex-direction: column;
         align-items: center;
         min-width: 140px;
-        cursor: default;
         transition: transform .1s;
     }
-    a .sponsor-tile {
-        cursor: pointer;
+    .sponsor-logo-link {
+        display: block;
+        text-decoration: none;
     }
-    a:hover .sponsor-tile {
-        transform: translate(-2px, -2px);
-        box-shadow: 6px 6px 0 var(--black);
+    .sponsor-logo-link:hover img {
+        opacity: .85;
     }
 </style>
 

--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -69,7 +69,14 @@
             @foreach (var m in _members)
             {
                 <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center">
-                    <div style="font-size:36px;margin-bottom:8px">@m.AvatarEmoji</div>
+                    @if (m.PhotoData is not null)
+                    {
+                        <img src="/staff-photo/@m.StaffMemberId" style="width:64px;height:64px;object-fit:cover;border-radius:8px;border:2px solid var(--black);margin-bottom:8px" alt="@m.DisplayName" />
+                    }
+                    else
+                    {
+                        <div style="font-size:36px;margin-bottom:8px">@m.AvatarEmoji</div>
+                    }
                     <div style="font-family:'Fredoka One',cursive;font-size:15px">@m.DisplayName</div>
                     <div style="font-size:12px;color:var(--text-light);margin-bottom:8px">@m.RoleTitle</div>
                     @if (!string.IsNullOrEmpty(m.Phone))
@@ -105,7 +112,23 @@
             <h3 style="font-family:'Fredoka One',cursive;margin:0 0 16px">@(_form.StaffMemberId == Guid.Empty ? "Add Staff Member" : "Edit Staff Member")</h3>
             <MudTextField @bind-Value="_form.DisplayName" Label="Name" Required="true" Class="mb-2" />
             <MudTextField @bind-Value="_form.RoleTitle"   Label="Role/Title" Class="mb-2" />
-            <MudTextField @bind-Value="_form.AvatarEmoji" Label="Avatar Emoji" Class="mb-2" />
+            <MudTextField @bind-Value="_form.AvatarEmoji" Label="Avatar Emoji (fallback if no photo)" Class="mb-2" />
+            <div style="margin-bottom:12px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Photo (JPEG/PNG, max 2 MB)</div>
+                <InputFile OnChange="HandlePhotoUpload" accept="image/*" style="font-size:13px;font-family:'Nunito',sans-serif" />
+                @if (!string.IsNullOrWhiteSpace(_photoUploadError))
+                {
+                    <div style="color:#D12B2B;font-size:12px;margin-top:4px">@_photoUploadError</div>
+                }
+                @if (_fPhotoData is not null)
+                {
+                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">✅ File ready to upload</div>
+                }
+                else if (_currentHasPhoto)
+                {
+                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">Current: uploaded photo (leave blank to keep)</div>
+                }
+            </div>
             <MudTextField @bind-Value="_form.Phone"       Label="Phone (optional)" Class="mb-2" />
             <MudTextField @bind-Value="_form.Email"       Label="Email (optional)" Class="mb-2" />
             <MudSwitch T="bool" @bind-Value="_form.IsVisible" Label="Visible in directory" Color="Color.Primary" Class="mb-2" />
@@ -125,6 +148,10 @@
     private List<StaffMember> _members = new();
     private List<User> _eligibleUsers = new();
     private StaffMember _form = new() { AvatarEmoji = "👤", IsVisible = true };
+    private byte[]? _fPhotoData;
+    private string? _fPhotoContentType;
+    private bool _currentHasPhoto;
+    private string _photoUploadError = "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -147,6 +174,7 @@
     private void OpenAdd()
     {
         _form = new() { CampEventId = SeedService.Id.EventCcn2026, AvatarEmoji = "👤", IsVisible = true };
+        _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = false; _photoUploadError = "";
         _showForm   = true;
         _showImport = false;
     }
@@ -160,17 +188,40 @@
             AvatarEmoji = m.AvatarEmoji, Phone = m.Phone, Email = m.Email,
             IsVisible = m.IsVisible, SortOrder = m.SortOrder, LinkedUserId = m.LinkedUserId
         };
+        _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = m.PhotoData is not null; _photoUploadError = "";
         _showForm   = true;
         _showImport = false;
     }
 
-    private void Close() => _showForm = false;
+    private void Close()
+    {
+        _showForm = false;
+        _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = false; _photoUploadError = "";
+    }
 
     private async Task Save()
     {
+        _form.PhotoData        = _fPhotoData;
+        _form.PhotoContentType = _fPhotoContentType;
         await StaffSvc.UpsertAsync(_form);
-        _showForm = false;
+        Close();
         await Reload();
+    }
+
+    private async Task HandlePhotoUpload(InputFileChangeEventArgs e)
+    {
+        _photoUploadError = "";
+        var file = e.File;
+        if (file.Size > 2 * 1024 * 1024)
+        {
+            _photoUploadError = "File too large — maximum 2 MB.";
+            return;
+        }
+        using var stream = file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        _fPhotoData = ms.ToArray();
+        _fPhotoContentType = file.ContentType;
     }
 
     private async Task Delete(Guid id)

--- a/CampClotNot/Pages/Index.razor
+++ b/CampClotNot/Pages/Index.razor
@@ -8,8 +8,8 @@
     {
         var ctx = HttpContextAccessor.HttpContext;
         if (ctx is not null && !ctx.Response.HasStarted)
-            ctx.Response.Redirect("/hub/schedule");
+            ctx.Response.Redirect("/dashboard");
         else
-            Nav.NavigateTo("/hub/schedule", replace: true);
+            Nav.NavigateTo("/dashboard", replace: true);
     }
 }

--- a/CampClotNot/Pages/Leaderboard.razor
+++ b/CampClotNot/Pages/Leaderboard.razor
@@ -1,0 +1,248 @@
+@page "/leaderboard"
+@attribute [Authorize]
+@inject GroupService GroupSvc
+@inject TransactionService TxSvc
+@inject NavigationManager Nav
+@inject IDialogService DialogService
+@inject ThemeService ThemeSvc
+@implements IAsyncDisposable
+
+<PageTitle>Leaderboard — Camp Clot Not</PageTitle>
+
+@if (_loading)
+{
+    <div style="display:flex;justify-content:center;padding:80px 0">
+        <MudProgressCircular Indeterminate="true" Color="Color.Primary" Size="Size.Large" />
+    </div>
+}
+else
+{
+    @* ── STANDINGS rank rows ── *@
+    <div class="ccn-section-label">🏆 Standings</div>
+    <div class="ccn-panel" style="margin-bottom:24px;overflow:hidden;animation:slideUp .3s ease">
+        @foreach (var entry in _ranked)
+        {
+            var rankBg = entry.Rank switch
+            {
+                1 => "background:var(--color-primary)",
+                2 => "background:#E8E8E8",
+                3 => "background:#F5EED8",
+                _ => "background:var(--panel-bg)"
+            };
+            var medals  = new[] { "🥇", "🥈", "🥉", "4️⃣" };
+            var medal   = entry.Rank <= medals.Length ? medals[entry.Rank - 1] : $"#{entry.Rank}";
+            var delay   = (entry.Rank - 1) * 60;
+            var initial = entry.Group.ShortName is { Length: > 0 } s ? s[..1] : "?";
+
+            <div class="ccn-rank-row" style="@rankBg;animation:slideUp .3s ease @(delay)ms both">
+
+                @* Rank medal *@
+                <div style="font-family:'Fredoka One',cursive;font-size:22px;width:36px;text-align:center;flex-shrink:0;color:var(--black)">
+                    @medal
+                </div>
+
+                @* Group avatar *@
+                <div style="@($"width:40px;height:40px;border-radius:50%;border:3px solid var(--black);background:{entry.Group.Color};display:flex;align-items:center;justify-content:center;font-family:'Fredoka One',cursive;font-size:16px;color:white;flex-shrink:0;box-shadow:2px 2px 0 var(--black);overflow:hidden")">
+                    @if (entry.Group.TokenAssetPath is not null)
+                    {
+                        <img src="@entry.Group.TokenAssetPath" style="width:100%;height:100%;object-fit:contain" />
+                    }
+                    else { @initial }
+                </div>
+
+                @* Name + board position *@
+                <div style="flex:1;min-width:0">
+                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black);
+                                white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
+                        @entry.Group.Name
+                    </div>
+                    @if (entry.Group.BoardPos is not null)
+                    {
+                        <div style="font-size:10px;color:var(--text-light);font-weight:700;margin-top:1px">
+                            Space @entry.Group.BoardPos.SpaceIndex
+                        </div>
+                    }
+                </div>
+
+                @* Score pills *@
+                <div style="display:flex;gap:6px;flex-shrink:0">
+                    <div style="display:flex;align-items:center;gap:5px;background:var(--color-accent);
+                                border:3px solid var(--black);border-radius:5px;padding:4px 10px;box-shadow:2px 2px 0 var(--black)">
+                        <img src="/img/ccn-coin.png" style="height:18px;width:auto" alt="coins" />
+                        <span style="font-family:'Fredoka One',cursive;font-size:17px;color:white">@entry.Coins</span>
+                    </div>
+                    <div style="display:flex;align-items:center;gap:5px;background:#2563C4;
+                                border:3px solid var(--black);border-radius:5px;padding:4px 10px;box-shadow:2px 2px 0 var(--black)">
+                        <img src="/img/ccn-star.png" style="height:18px;width:auto" alt="stars" />
+                        <span style="font-family:'Fredoka One',cursive;font-size:17px;color:white">@entry.Stars</span>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    @* ── QUICK ACTIONS group cards ── *@
+    <div class="ccn-section-label">⚡ Quick Actions</div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-bottom:24px">
+        @foreach (var entry in _ranked)
+        {
+            var delay   = (entry.Rank - 1) * 60;
+            var initial = entry.Group.ShortName is { Length: > 0 } sn ? sn[..1] : "?";
+            <div class="ccn-panel" style="padding:14px;border-top:5px solid @entry.Group.Color;animation:slideUp .3s ease @(delay)ms both">
+
+                <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
+                    <div style="@($"width:40px;height:40px;border-radius:50%;border:3px solid var(--black);background:{entry.Group.Color};display:flex;align-items:center;justify-content:center;font-family:'Fredoka One',cursive;font-size:16px;color:white;flex-shrink:0;box-shadow:2px 2px 0 var(--black);overflow:hidden")">
+                        @if (entry.Group.TokenAssetPath is not null)
+                        {
+                            <img src="@entry.Group.TokenAssetPath" style="width:100%;height:100%;object-fit:contain" />
+                        }
+                        else { @initial }
+                    </div>
+                    <div>
+                        <div style="font-family:'Fredoka One',cursive;font-size:14px;color:var(--black)">@entry.Group.Name</div>
+                        @if (entry.Group.BoardPos is not null)
+                        {
+                            <div style="font-size:10px;color:var(--text-light);font-weight:700;margin-top:1px">
+                                Space @entry.Group.BoardPos.SpaceIndex
+                            </div>
+                        }
+                    </div>
+                </div>
+
+                <div style="display:flex;gap:10px;margin-bottom:12px">
+                    <div style="flex:1;border:3px solid var(--black);border-radius:7px;border-top:4px solid var(--color-primary);padding:8px 12px;text-align:center;box-shadow:2px 2px 0 var(--black)">
+                        <div style="font-family:'Fredoka One',cursive;font-size:28px;line-height:1;color:var(--black)">@entry.Coins</div>
+                        <div style="display:flex;align-items:center;justify-content:center;gap:4px;margin-top:3px">
+                            <img src="/img/ccn-coin.png" style="height:12px;width:auto" alt="coins" />
+                            <span style="font-size:9px;font-weight:800;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-mid)">Coins</span>
+                        </div>
+                    </div>
+                    <div style="flex:1;border:3px solid var(--black);border-radius:7px;border-top:4px solid var(--color-accent);padding:8px 12px;text-align:center;box-shadow:2px 2px 0 var(--black)">
+                        <div style="font-family:'Fredoka One',cursive;font-size:28px;line-height:1;color:var(--black)">@entry.Stars</div>
+                        <div style="display:flex;align-items:center;justify-content:center;gap:4px;margin-top:3px">
+                            <img src="/img/ccn-star.png" style="height:12px;width:auto" alt="stars" />
+                            <span style="font-size:9px;font-weight:800;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-mid)">Stars</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div style="display:flex;gap:8px">
+                    <button class="ccn-btn" style="flex:1;background:var(--color-primary);font-size:12px;padding:6px 10px"
+                            @onclick="@(() => OpenTransactionDialog(entry.Group.GroupId, Currency.Primary))">
+                        + Coins
+                    </button>
+                    <button class="ccn-btn" style="flex:1;background:var(--color-accent);color:white;font-size:12px;padding:6px 10px"
+                            @onclick="@(() => OpenTransactionDialog(entry.Group.GroupId, Currency.Prestige))">
+                        + Stars
+                    </button>
+                </div>
+            </div>
+        }
+    </div>
+
+    @* ── RECENT ACTIVITY ── *@
+    @if (_recentTransactions.Any())
+    {
+        <div class="ccn-section-label">🕐 Recent Activity</div>
+        <div class="ccn-panel" style="overflow:hidden;margin-bottom:80px">
+            @for (int i = 0; i < _recentTransactions.Count; i++)
+            {
+                var tx        = _recentTransactions[i];
+                var isPrimary = tx.CurrencyType?.SystemName == nameof(Currency.Primary);
+                var sep       = i < _recentTransactions.Count - 1 ? "border-bottom:2px solid #E8E0CC" : "";
+
+                <div style="display:flex;align-items:center;gap:12px;padding:12px 14px;@sep">
+                    <div style="@($"width:36px;height:36px;border-radius:6px;border:2px solid var(--black);background:{(isPrimary ? "var(--color-primary)" : "var(--color-accent)")};display:flex;align-items:center;justify-content:center;flex-shrink:0;box-shadow:2px 2px 0 var(--black)")">
+                        <img src="@(isPrimary ? "/img/ccn-coin.png" : "/img/ccn-star.png")" style="height:22px;width:auto" alt="@(isPrimary ? "coin" : "star")" />
+                    </div>
+                    <div style="flex:1;min-width:0">
+                        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+                            <span style="@($"font-family:'Fredoka One',cursive;font-size:13px;color:{tx.Group?.Color ?? "var(--black)"}")">@tx.Group?.Name</span>
+                            <span style="font-weight:800;font-size:13px;color:@(tx.Amount > 0 ? "var(--color-success)" : "var(--color-accent)")">
+                                @(tx.Amount > 0 ? "+" : "")@tx.Amount @(isPrimary ? "coins" : "stars")
+                            </span>
+                        </div>
+                        <div style="font-size:10px;color:var(--text-light);margin-top:2px;font-weight:700">
+                            @(tx.Note != null ? $"{tx.Note} · " : "")@tx.LoggedBy · @tx.CreatedAt.ToLocalTime().ToString("h:mm tt")
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}
+
+@* ── Log Score FAB ── *@
+<button class="ccn-btn ccn-fab-mobile" style="position:fixed;bottom:24px;right:24px;background:var(--color-accent);color:white;
+                                font-size:15px;padding:13px 24px;border-radius:50px;border-color:var(--black);
+                                box-shadow:4px 4px 0 var(--black);z-index:50;
+                                display:flex;align-items:center;gap:8px"
+        @onclick="OpenTransactionDialog">
+    ＋ Log Score
+</button>
+
+<LogTransactionDialog @ref="_txDialog" OnTransactionPosted="RefreshAsync" />
+
+@code {
+    private List<GroupEntry>   _ranked             = new();
+    private List<Transaction>  _recentTransactions = new();
+    private bool               _loading            = true;
+    private LogTransactionDialog _txDialog         = null!;
+    private HubConnection?     _hub;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshAsync();
+        _loading = false;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        _hub = new HubConnectionBuilder()
+            .WithUrl(Nav.ToAbsoluteUri("/livehub"))
+            .WithAutomaticReconnect()
+            .Build();
+
+        _hub.On("ScoresUpdated", async () =>
+        {
+            await RefreshAsync();
+            await InvokeAsync(StateHasChanged);
+        });
+
+        await _hub.StartAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        var groups  = await GroupSvc.GetAllAsync();
+        var entries = new List<GroupEntry>();
+        foreach (var g in groups)
+        {
+            var coins = await GroupSvc.GetTotalAsync(g.GroupId, Currency.Primary);
+            var stars = await GroupSvc.GetTotalAsync(g.GroupId, Currency.Prestige);
+            entries.Add(new GroupEntry(g, coins, stars));
+        }
+        _ranked = entries
+            .OrderByDescending(e => e.Stars)
+            .ThenByDescending(e => e.Coins)
+            .Select((e, i) => e with { Rank = i + 1 })
+            .ToList();
+
+        var allTx = await TxSvc.GetAllAsync();
+        _recentTransactions = allTx.Where(t => t.VoidedAt == null).Take(5).ToList();
+    }
+
+    private async Task OpenTransactionDialog() => await _txDialog.OpenAsync();
+
+    private async Task OpenTransactionDialog(Guid groupId, Currency currency)
+        => await _txDialog.OpenAsync(groupId, currency);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hub is not null) await _hub.DisposeAsync();
+    }
+
+    private record GroupEntry(Group Group, int Coins, int Stars, int Rank = 0);
+}

--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -120,7 +120,7 @@ try
         var email    = form["email"].ToString();
         var password = form["password"].ToString();
         var ok = await auth.LoginAsync(ctx, email, password);
-        return ok ? Results.Redirect("/hub/schedule") : Results.Redirect("/login?error=true");
+        return ok ? Results.Redirect("/dashboard") : Results.Redirect("/login?error=true");
     });
 
     app.MapGet("/logout", async (HttpContext ctx) =>
@@ -136,6 +136,22 @@ try
         if (s?.LogoData is null) return Results.NotFound();
         return Results.File(s.LogoData, s.LogoContentType ?? "image/jpeg");
     });
+
+    app.MapGet("/staff-photo/{id:guid}", async (Guid id, IDbContextFactory<AppDbContext> factory) =>
+    {
+        using var db = factory.CreateDbContext();
+        var member = await db.StaffMembers.FindAsync(id);
+        if (member?.PhotoData is null) return Results.NotFound();
+        return Results.File(member.PhotoData, member.PhotoContentType ?? "image/jpeg");
+    }).AllowAnonymous();
+
+    app.MapGet("/location-image/{id:guid}", async (Guid id, IDbContextFactory<AppDbContext> factory) =>
+    {
+        using var db = factory.CreateDbContext();
+        var loc = await db.Locations.FindAsync(id);
+        if (loc?.ImageData is null) return Results.NotFound();
+        return Results.File(loc.ImageData, loc.ImageContentType ?? "image/jpeg");
+    }).AllowAnonymous();
 
     app.MapHub<LiveHub>("/livehub");
     app.MapBlazorHub();

--- a/CampClotNot/Services/BoardService.cs
+++ b/CampClotNot/Services/BoardService.cs
@@ -12,7 +12,8 @@ public record BoardSpaceView(
     float XPos,
     float YPos,
     string CategorySystemName,
-    string ActivityName
+    string ActivityName,
+    Guid? LocationId = null
 );
 
 public class BoardService(
@@ -29,6 +30,8 @@ public class BoardService(
             .Include(s => s.Activity)
                 .ThenInclude(a => a.ActivityType)
                     .ThenInclude(at => at.Category)
+            .Include(s => s.Activity)
+                .ThenInclude(a => a.Location)
             .OrderBy(s => s.SpaceIndex)
             .ToListAsync();
 
@@ -38,7 +41,8 @@ public class BoardService(
             s.XPos,
             s.YPos,
             s.Activity.ActivityType.Category.SystemName,
-            s.Activity.Name
+            s.Activity.Name,
+            s.Activity.Location?.ImageData is not null ? s.Activity.LocationId : null
         )).ToList();
     }
 

--- a/CampClotNot/Services/IncidentReportService.cs
+++ b/CampClotNot/Services/IncidentReportService.cs
@@ -10,6 +10,7 @@ public class IncidentReportService(IDbContextFactory<AppDbContext> factory)
     {
         using var db = factory.CreateDbContext();
         return await db.IncidentReports
+            .Include(r => r.IncidentLocation)
             .Where(r => r.EventId == eventId)
             .OrderByDescending(r => r.SubmittedAt)
             .ToListAsync();
@@ -18,7 +19,9 @@ public class IncidentReportService(IDbContextFactory<AppDbContext> factory)
     public async Task<IncidentReport?> GetByIdAsync(Guid id)
     {
         using var db = factory.CreateDbContext();
-        return await db.IncidentReports.FindAsync(id);
+        return await db.IncidentReports
+            .Include(r => r.IncidentLocation)
+            .FirstOrDefaultAsync(r => r.IncidentReportId == id);
     }
 
     public async Task<IncidentReport> SubmitAsync(IncidentReport report)

--- a/CampClotNot/Services/LocationService.cs
+++ b/CampClotNot/Services/LocationService.cs
@@ -27,6 +27,11 @@ public class LocationService(IDbContextFactory<AppDbContext> factory)
             existing.Description = loc.Description;
             existing.Capacity    = loc.Capacity;
             existing.SortOrder   = loc.SortOrder;
+            if (loc.ImageData is not null)
+            {
+                existing.ImageData        = loc.ImageData;
+                existing.ImageContentType = loc.ImageContentType;
+            }
         }
         await db.SaveChangesAsync();
         return loc;

--- a/CampClotNot/Services/MiniGameService.cs
+++ b/CampClotNot/Services/MiniGameService.cs
@@ -107,7 +107,7 @@ public class MiniGameService(
         await hub.Clients.All.SendAsync("MiniGameSpinReset");
     }
 
-    public async Task UpsertActivityAsync(Guid activityId, Guid eventId, string name, string description)
+    public async Task UpsertActivityAsync(Guid activityId, Guid eventId, string name, string description, Guid? locationId = null)
     {
         using var db = factory.CreateDbContext();
         var existing = await db.Activities.FindAsync(activityId);
@@ -119,13 +119,15 @@ public class MiniGameService(
                 EventId        = eventId,
                 ActivityTypeId = SeedService.Id.ActTypeMtwiPlaceholder,
                 Name           = name,
-                Description    = description
+                Description    = description,
+                LocationId     = locationId
             });
         }
         else
         {
             existing.Name        = name;
             existing.Description = description;
+            existing.LocationId  = locationId;
         }
         await db.SaveChangesAsync();
     }

--- a/CampClotNot/Services/ScheduleService.cs
+++ b/CampClotNot/Services/ScheduleService.cs
@@ -18,7 +18,9 @@ public record ScheduleEventDto(
     ScheduleEventType EventType,
     bool AppliesToAllGroups,
     int? MaxCapacity,
-    List<GroupAssignmentDto> Assignments
+    List<GroupAssignmentDto> Assignments,
+    string? PresenterName = null,
+    string? PresenterBio = null
 );
 
 public class ScheduleService(IDbContextFactory<AppDbContext> factory)
@@ -77,6 +79,8 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
                 EventType          = dto.EventType,
                 AppliesToAllGroups = dto.AppliesToAllGroups,
                 MaxCapacity        = dto.MaxCapacity,
+                PresenterName      = dto.PresenterName,
+                PresenterBio       = dto.PresenterBio,
                 CreatedBy          = userId,
                 UpdatedAt          = DateTime.UtcNow,
                 EventGroups        = dto.Assignments
@@ -104,6 +108,8 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
             existing.EventType          = dto.EventType;
             existing.AppliesToAllGroups = dto.AppliesToAllGroups;
             existing.MaxCapacity        = dto.MaxCapacity;
+            existing.PresenterName      = dto.PresenterName;
+            existing.PresenterBio       = dto.PresenterBio;
             existing.UpdatedAt          = DateTime.UtcNow;
 
             db.ScheduleEventGroups.RemoveRange(existing.EventGroups);

--- a/CampClotNot/Services/SeedService.cs
+++ b/CampClotNot/Services/SeedService.cs
@@ -10,9 +10,10 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
     public static class Id
     {
         // UserRoles
-        public static readonly Guid RoleAdmin     = new("00000001-0001-0001-0001-000000000001");
-        public static readonly Guid RoleStaff     = new("00000001-0001-0001-0001-000000000002");
-        public static readonly Guid RoleVolunteer = new("00000001-0001-0001-0001-000000000004");
+        public static readonly Guid RoleAdmin        = new("00000001-0001-0001-0001-000000000001");
+        public static readonly Guid RoleStaff        = new("00000001-0001-0001-0001-000000000002");
+        public static readonly Guid RoleMedicalStaff = new("00000001-0001-0001-0001-000000000003");
+        public static readonly Guid RoleVolunteer    = new("00000001-0001-0001-0001-000000000004");
 
         // Authorities
         public static readonly Guid AuthLogTransaction   = new("00000002-0002-0002-0002-000000000001");
@@ -143,9 +144,10 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
     {
         var defs = new[]
         {
-            new { Id = Id.RoleAdmin,     Name = "Admin",     Description = "Full system access",                       SystemName = nameof(Role.Admin) },
-            new { Id = Id.RoleStaff,     Name = "Staff",     Description = "Camp staff — full Hub access",             SystemName = nameof(Role.Staff) },
-            new { Id = Id.RoleVolunteer, Name = "Volunteer", Description = "Counselor / volunteer — limited access",   SystemName = nameof(Role.Volunteer) },
+            new { Id = Id.RoleAdmin,        Name = "Admin",         Description = "Full system access",                            SystemName = nameof(Role.Admin) },
+            new { Id = Id.RoleStaff,        Name = "Staff",         Description = "Camp staff — full Hub access",                  SystemName = nameof(Role.Staff) },
+            new { Id = Id.RoleMedicalStaff, Name = "Medical Staff", Description = "Medical team — can view and act on incidents",  SystemName = nameof(Role.MedicalStaff) },
+            new { Id = Id.RoleVolunteer,    Name = "Volunteer",     Description = "Counselor / volunteer — limited access",        SystemName = nameof(Role.Volunteer) },
         };
         foreach (var def in defs)
         {
@@ -189,9 +191,11 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
             new { RoleId = Id.RoleAdmin,     AuthId = Id.AuthManageShop },
             new { RoleId = Id.RoleAdmin,     AuthId = Id.AuthAccessAdminPanel },
             // Staff: transactions
-            new { RoleId = Id.RoleStaff,     AuthId = Id.AuthLogTransaction },
+            new { RoleId = Id.RoleStaff,        AuthId = Id.AuthLogTransaction },
+            // Medical Staff: transactions only (incident view handled by role check in UI/service, not Authority)
+            new { RoleId = Id.RoleMedicalStaff, AuthId = Id.AuthLogTransaction },
             // Volunteer: transactions only
-            new { RoleId = Id.RoleVolunteer, AuthId = Id.AuthLogTransaction },
+            new { RoleId = Id.RoleVolunteer,    AuthId = Id.AuthLogTransaction },
         };
         foreach (var def in defs)
         {
@@ -333,10 +337,9 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
 
     private async Task SeedGroupsAsync(AppDbContext db)
     {
-        // CCN 2026 confirmed cabin groups.
+        // CCN 2026 confirmed cabin groups — 3 groups (Mini Marios removed before camp).
         var defs = new[]
         {
-            new { Id = Id.Group1, Name = "Mini Marios",        ShortName = "MM", Color = "#E74C3C", Logo = "/img/mini-marios-logo.png" },
             new { Id = Id.Group2, Name = "Blue Shell Bandits", ShortName = "BB", Color = "#2980B9", Logo = "/img/blue-shell-bandits-logo.png" },
             new { Id = Id.Group3, Name = "Mushroom Militia",   ShortName = "MU", Color = "#27AE60", Logo = "/img/mushroom-militia-logo.png" },
             new { Id = Id.Group4, Name = "Luma Legends",       ShortName = "LL", Color = "#8E44AD", Logo = "/img/luma-legends-logo.png" },
@@ -526,7 +529,7 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
     // Initialize all groups at the Start space (index 0); skip groups that already have a position
     private async Task SeedGroupBoardPositionsAsync(AppDbContext db)
     {
-        var groupIds = new[] { Id.Group1, Id.Group2, Id.Group3, Id.Group4 };
+        var groupIds = new[] { Id.Group2, Id.Group3, Id.Group4 };
         foreach (var groupId in groupIds)
         {
             if (!await db.GroupBoardPositions.AnyAsync(p => p.GroupId == groupId))

--- a/CampClotNot/Services/SponsorService.cs
+++ b/CampClotNot/Services/SponsorService.cs
@@ -33,10 +33,12 @@ public class SponsorService(IDbContextFactory<AppDbContext> factory)
         }
         else
         {
-            existing.Name            = s.Name;
-            existing.LogoUrl         = s.LogoUrl;
-            existing.Website         = s.Website;
-            existing.SortOrder       = s.SortOrder;
+            existing.Name        = s.Name;
+            existing.LogoUrl     = s.LogoUrl;
+            existing.Website     = s.Website;
+            existing.ContactName = s.ContactName;
+            existing.Phone       = s.Phone;
+            existing.SortOrder   = s.SortOrder;
             if (s.LogoData is not null)
             {
                 existing.LogoData        = s.LogoData;
@@ -45,6 +47,19 @@ public class SponsorService(IDbContextFactory<AppDbContext> factory)
         }
         await db.SaveChangesAsync();
         return s;
+    }
+
+    public async Task UpdateSortOrderAsync(List<Sponsor> ordered)
+    {
+        using var db = factory.CreateDbContext();
+        var ids = ordered.Select(s => s.SponsorId).ToList();
+        var existing = await db.Sponsors.Where(s => ids.Contains(s.SponsorId)).ToListAsync();
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            var match = existing.FirstOrDefault(s => s.SponsorId == ordered[i].SponsorId);
+            if (match is not null) match.SortOrder = i;
+        }
+        await db.SaveChangesAsync();
     }
 
     public async Task DeleteAsync(Guid sponsorId)

--- a/CampClotNot/Services/StaffDirectoryService.cs
+++ b/CampClotNot/Services/StaffDirectoryService.cs
@@ -87,6 +87,11 @@ public class StaffDirectoryService(IDbContextFactory<AppDbContext> factory)
             existing.IsVisible    = member.IsVisible;
             existing.SortOrder    = member.SortOrder;
             existing.LinkedUserId = member.LinkedUserId;
+            if (member.PhotoData is not null)
+            {
+                existing.PhotoData        = member.PhotoData;
+                existing.PhotoContentType = member.PhotoContentType;
+            }
         }
         await db.SaveChangesAsync();
     }

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -206,6 +206,7 @@
     <AuthorizeView>
         <Authorized>
             <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+                <a href="/dashboard" class="nav-link" style="@ActiveStyle("/dashboard", "#27AE60")">🏠 Home</a>
                 <a href="/hub/schedule" class="nav-link" style="@ActiveStyle("/hub/schedule", "#2980B9")">📅 Schedule</a>
 
                 @* ── Hub dropdown ── *@
@@ -247,8 +248,10 @@
                     @if (_gameDropdownOpen)
                     {
                         <div class="nav-admin-panel">
-                            <a href="/dashboard" @onclick="() => _gameDropdownOpen = false">📊 Leaderboard</a>
-                            <a href="/board" @onclick="() => _gameDropdownOpen = false">🗺️ Board Game</a>
+                            <a href="/leaderboard" @onclick="() => _gameDropdownOpen = false">📊 Leaderboard</a>
+                            <AuthorizeView Roles="Admin,Staff" Context="boardCtx">
+                                <a href="/board" @onclick="() => _gameDropdownOpen = false">🗺️ Board Game</a>
+                            </AuthorizeView>
                             <AuthorizeView Roles="Admin" Context="gameAdminCtx">
                                 <a href="/minigames" @onclick="() => _gameDropdownOpen = false">🎲 Mini-Game</a>
                                 <button @onclick="() => { _gameDropdownOpen = false; OnLeaderboardClick.InvokeAsync(); }">📺 Projector</button>
@@ -298,6 +301,10 @@
 <AuthorizeView>
     <Authorized>
         <div class="nav-bottom-bar">
+            <a href="/dashboard" class="nav-tab @(IsDashboardActive() ? "active" : "")">
+                <span class="tab-icon">🏠</span>
+                <span>Home</span>
+            </a>
             <a href="/hub/schedule" class="nav-tab @(IsScheduleActive() ? "active" : "")">
                 <span class="tab-icon">📅</span>
                 <span>Schedule</span>
@@ -328,8 +335,10 @@
     <div style="position:fixed;inset:0;z-index:51;background:rgba(26,26,26,.4)"
          @onclick="() => _gameSheetOpen = false"></div>
     <div class="nav-game-sheet">
-        <a href="/dashboard" @onclick="() => _gameSheetOpen = false">📊 Leaderboard</a>
-        <a href="/board"     @onclick="() => _gameSheetOpen = false">🗺️ Board Game</a>
+        <a href="/leaderboard" @onclick="() => _gameSheetOpen = false">📊 Leaderboard</a>
+        <AuthorizeView Roles="Admin,Staff">
+            <a href="/board" @onclick="() => _gameSheetOpen = false">🗺️ Board Game</a>
+        </AuthorizeView>
         <AuthorizeView Roles="Admin">
             <a href="/minigames" @onclick="() => _gameSheetOpen = false">🎲 Mini-Game</a>
         </AuthorizeView>
@@ -369,6 +378,8 @@
             : ("/" + Nav.ToBaseRelativePath(Nav.Uri))
                 .StartsWith(href, StringComparison.OrdinalIgnoreCase);
 
+    private bool IsDashboardActive() => IsActive("/dashboard");
+
     private bool IsScheduleActive() => IsActive("/hub/schedule");
 
     private bool IsHubActive()
@@ -379,7 +390,7 @@
     }
 
     private bool IsGameActive() =>
-        IsActive("/dashboard") || IsActive("/board") || IsActive("/minigames");
+        IsActive("/leaderboard") || IsActive("/board") || IsActive("/minigames");
 
     private string ActiveStyle(string href, string color)
     {

--- a/CampClotNot/Shared/BoardComponent.razor
+++ b/CampClotNot/Shared/BoardComponent.razor
@@ -36,11 +36,17 @@
             @* Space circle *@
             <circle cx="@sx" cy="@sy" r="18" fill="@spColor" stroke="#0e1628" stroke-width="3" opacity="0.93" />
 
-            @* Space icon — wrapped in <g> so Razor parses <text> as SVG not pseudo-element *@
-            <g>
-                <text x="@sx" y="@(sy + 1)" text-anchor="middle" dominant-baseline="middle" font-size="13">@spIcon</text>
-                <text x="@sx" y="@(sy + 28)" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.35)">@space.SpaceIndex</text>
-            </g>
+            @* Space icon or location image *@
+            @if (space.LocationId is not null)
+            {
+                <image href="/location-image/@space.LocationId" x="@(sx - 14)" y="@(sy - 14)" width="28" height="28"
+                       preserveAspectRatio="xMidYMid slice" />
+            }
+            else
+            {
+                <g><text x="@sx" y="@(sy + 1)" text-anchor="middle" dominant-baseline="middle" font-size="13">@spIcon</text></g>
+            }
+            <g><text x="@sx" y="@(sy + 28)" text-anchor="middle" font-size="8" fill="rgba(255,255,255,0.35)">@space.SpaceIndex</text></g>
 
             </g>
     }

--- a/CampClotNot/Shared/MainLayout.razor
+++ b/CampClotNot/Shared/MainLayout.razor
@@ -11,7 +11,7 @@
 
 <AppNav OnLeaderboardClick="@(() => _showProjector = true)" />
 
-<div style="padding:20px 18px 80px">
+<div style="padding:20px 18px calc(80px + env(safe-area-inset-bottom))">
     @Body
 </div>
 

--- a/CampClotNot/Shared/RedirectToLogin.razor
+++ b/CampClotNot/Shared/RedirectToLogin.razor
@@ -1,17 +1,27 @@
 @inject NavigationManager Nav
 @inject IHttpContextAccessor HttpCtx
+@inject AuthenticationStateProvider AuthState
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         var http = HttpCtx.HttpContext;
-        // During prerendering HttpContext is available — use a real HTTP redirect
-        // so NavigationException never bubbles up through the dev exception page.
-        // During the interactive SignalR circuit HttpContext is null, so fall back
-        // to NavigateTo which Blazor's router handles correctly.
         if (http is not null && !http.Response.HasStarted)
-            http.Response.Redirect("/login");
+        {
+            // During prerendering: authenticated users who lack a role go to dashboard,
+            // unauthenticated users go to login.
+            if (http.User.Identity?.IsAuthenticated == true)
+                http.Response.Redirect("/dashboard");
+            else
+                http.Response.Redirect("/login");
+        }
         else
-            Nav.NavigateTo("/login", forceLoad: true);
+        {
+            var state = await AuthState.GetAuthenticationStateAsync();
+            if (state.User.Identity?.IsAuthenticated == true)
+                Nav.NavigateTo("/dashboard", replace: true);
+            else
+                Nav.NavigateTo("/login", forceLoad: true);
+        }
     }
 }

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -312,9 +312,12 @@ InfoPage           — PageId, EventId, Slug (unique), Title, Body (markdown), I
                      SortOrder, UpdatedAt, UpdatedByUserId
 IncidentReport     — IncidentReportId, EventId, DateOfIncident, DateCompleted,
                      PersonsInvolved, Description, RecommendedAction,
+                     IncidentLocationId (FK→Location)?, IncidentLocationOther?,
+                     ReportType (enum: Internal|ChildrensHarbor),
                      SubmittedByUserId, SubmittedByName, SubmittedByRole, SubmittedAt,
                      IsAcknowledged, AcknowledgedByUserId?, AcknowledgedByName?, AcknowledgedAt?
-Sponsor            — SponsorId, EventId, Name, LogoUrl?, LogoData (binary)?, LogoContentType?, Website?, SortOrder
+Sponsor            — SponsorId, EventId, Name, LogoUrl?, LogoData (binary)?, LogoContentType?,
+                     Website?, ContactName?, Phone?, SortOrder
 
 -- Future / v1.1+
 PushSubscription   — SubscriptionId, UserId, Endpoint, P256DH, Auth,
@@ -540,6 +543,7 @@ Camp is June 20-25, 2026.
 | ~June 2 | v0.5.2 — Schedule Admin + Sponsor Logos ✅ | Sponsor binary logo upload, `/admin/schedule` CRUD, schedule day tabs, nav restructure, `/` → `/hub/schedule` redirect |
 | ~June 2 | v0.5.3 — Activities Admin ✅ | `/admin/activities` CRUD for MinuteToWinIt activities (Vicki/Amanda configurable) |
 | ~June 2 | v0.5.4 — Schedule Save Fix ✅ | Bug fix: EF shadow FK on `ScheduleEvent.CreatedByUser` caused circuit crash on save; explicit `HasForeignKey` + migration |
+| ~June 7 | v0.5.5 — UX Improvements | Dashboard landing page, incident enhancements, staff photos, Medical Staff role, sponsor improvements, schedule improvements (see §8.14) |
 | ~June 7-8 | v1.0.0-rc — Dry Run | Full dress rehearsal. Staff test on real devices. Projector verified. Issues logged. |
 | ~June 13 | v1.0.0 — Camp Ready | Dry run issues resolved. Production seeded. Staff briefed. One week buffer. |
 | June 20 | 🏕️ CAMP | Super Clot Not Party '26 is live |
@@ -874,21 +878,23 @@ InfoPage — PageId, Slug (unique), Title, Body (markdown), IconEmoji,
 
 ### 8.5 Role Permission Matrix
 
-| Feature | Admin | Staff | Volunteer |
-|---|---|---|---|
-| View Schedule | ✅ | ✅ | ✅ |
-| Edit Schedule | ✅ | ✅ | ❌ |
-| View Announcements | ✅ | ✅ | ✅ |
-| Post Announcement (Normal) | ✅ | ✅ | ❌ |
-| Post Urgent / Pin | ✅ | ❌ | ❌ |
-| View Staff Directory | ✅ | ✅ | ✅ |
-| Edit Staff Directory | ✅ | ❌ | ❌ |
-| View Info Pages | ✅ | ✅ | ✅ |
-| Edit Info Page Body | ✅ | ❌ | ❌ |
-| View Sponsors | ✅ | ✅ | ✅ |
-| Manage Sponsors | ✅ | ❌ | ❌ |
-| Submit Incident Report | ✅ | ✅ | ✅ |
-| View / Acknowledge Incidents | ✅ | ❌ | ❌ |
+| Feature | Admin | Staff | MedicalStaff | Volunteer |
+|---|---|---|---|---|
+| View Schedule | ✅ | ✅ | ✅ | ✅ |
+| Edit Schedule | ✅ | ✅ | ❌ | ❌ |
+| View Announcements | ✅ | ✅ | ✅ | ✅ |
+| Post Announcement (Normal) | ✅ | ✅ | ❌ | ❌ |
+| Post Urgent / Pin | ✅ | ❌ | ❌ | ❌ |
+| View Staff Directory | ✅ | ✅ | ✅ | ✅ |
+| Edit Staff Directory | ✅ | ❌ | ❌ | ❌ |
+| View Info Pages | ✅ | ✅ | ✅ | ✅ |
+| Edit Info Page Body | ✅ | ❌ | ❌ | ❌ |
+| View Sponsors | ✅ | ✅ | ✅ | ✅ |
+| Manage Sponsors | ✅ | ❌ | ❌ | ❌ |
+| Log Transactions | ✅ | ✅ | ✅ | ✅ |
+| Submit Incident Report | ✅ | ✅ | ✅ | ✅ |
+| View / Acknowledge Incidents | ✅ | ❌ | ✅ | ❌ |
+| Select Children's Harbor Report Type | ✅ | ❌ | ❌ | ❌ |
 
 Projector display pages (`/board/display`, `/minigames/display`) are Admin-only — no Hub access.
 
@@ -995,29 +1001,45 @@ Implement PWA last, after all Hub features are functional. No logic dependencies
 
 ---
 
-### 8.10 Incident Reports (v0.5.1)
+### 8.10 Incident Reports (v0.5.1 base; enhancements in v0.5.5)
 
-A floating "🚨 Report Incident" button appears on all Hub pages (rendered in `HubSubNav.razor`). Any logged-in user (Admin, Staff, Volunteer) can submit. Only Admin can view submitted reports.
+A floating "🚨 Report Incident" button appears on all Hub pages (rendered in `HubSubNav.razor`). Any logged-in user (Admin, Staff, Volunteer, MedicalStaff) can submit. Admin and MedicalStaff can view submitted reports.
 
-**Form fields:** Date of Incident, Date Completed (auto-today), Persons Involved, Description (including lead-up and responses), Recommended Action. Submitter info auto-captured from auth claims — no signature fields.
+**Form fields (v0.5.5 additions in bold):**
+- Date of Incident, Date Completed (auto-today), Persons Involved, Description (including lead-up and responses), Recommended Action
+- **Incident Location:** dropdown populated from active event's `Location` records, with "Other" always appended. When "Other" is selected, a free-text input appears and saves to `IncidentLocationOther`. Display: Location name if FK set, else "Other: {IncidentLocationOther}".
+- **Report Type** (`IncidentReportType` enum): `Internal` (default, selectable by all) or `ChildrensHarbor` (Admin-only). Non-admin submitters see only "Internal" — the field is auto-set and not shown. Admin submitters see a dropdown to choose.
 
-**Admin view:** `/hub/incidents` — lists all reports newest-first. Each row: date, submitter name/role, persons involved (truncated), Acknowledge button, Print link. Acknowledged rows show who acknowledged and when.
+**Admin/MedicalStaff view:** `/hub/incidents` — lists all reports newest-first. Visible to Admin and MedicalStaff roles.
 
-**Print view:** `/hub/incidents/{id}/print` — uses `PrintLayout` (bare layout, no nav). Mirrors the Children's Harbor paper form: logo top-right, "INCIDENT REPORT FORM" centered title, fields in paper layout order, submitter footer. Print button calls `window.print()` and is hidden via `@media print`.
+**Print view:** `/hub/incidents/{id}/print` — uses `PrintLayout`. Mirrors the Children's Harbor paper form. Report Type shown in header.
 
 **System name:** `IncidentReport` / `IncidentReportService` / `/hub/incidents`
 
+**Data model (v0.5.5):**
+```
+IncidentReport — ... (existing fields) ...
+                 IncidentLocationId (Guid? FK → Location),
+                 IncidentLocationOther (string?),
+                 ReportType (IncidentReportType: Internal=0, ChildrensHarbor=1)
+```
+
 ---
 
-### 8.11 Sponsors (v0.5.1)
+### 8.11 Sponsors (v0.5.1 base; enhancements in v0.5.5)
 
-Admin manages a list of event sponsors (name, logo URL, optional website link, sort order). All users can view a Sponsors tab in the Hub.
+Admin manages a list of event sponsors. All users can view a Sponsors tab in the Hub. Sponsors are prominently featured on the Dashboard landing page (Vicki emphasis).
 
-**Display page:** `/hub/sponsors` — responsive grid of logo tiles. Each tile: logo (constrained 80px height), sponsor name below. If Website is set, the tile is a link. Visible to Admin, Staff, Volunteer.
+**Display page:** `/hub/sponsors` — responsive grid of logo tiles. Each tile: logo (constrained 80px height), sponsor name, **contact name + clickable `tel:` phone link (v0.5.5)** when present. If Website is set, the tile is a link.
 
-**Admin CRUD:** `/admin/sponsors` — same table/form panel pattern as `/admin/locations`. Accessible from Admin desktop dropdown and mobile admin sheet.
+**Admin CRUD:** `/admin/sponsors` — form panel + table pattern. **Drag-and-drop row reordering (v0.5.5)**: admin can drag rows to reorder; `SortOrder` is persisted to DB on drop. Order on `/hub/sponsors` (all roles) reflects the saved `SortOrder`. Implementation: HTML5 drag events via Blazor (no third-party library).
 
-**Logo storage:** Binary upload supported as of v0.5.2. `Sponsor` entity has `LogoData (byte[]?)` + `LogoContentType (string?)`. Logo served via streaming endpoint `/sponsor-logo/{id}`. Falls back to `LogoUrl` string if no binary data. `LogoUrl` remains nullable.
+**Logo storage:** `LogoData (byte[]?)` + `LogoContentType (string?)` — served via `/sponsor-logo/{id}`.
+
+**Data model (v0.5.5 additions):**
+```
+Sponsor — ... (existing) ..., ContactName (string?), Phone (string?)
+```
 
 **System name:** `Sponsor` / `SponsorService` / `/hub/sponsors`
 
@@ -1026,6 +1048,93 @@ Admin manages a list of event sponsors (name, logo URL, optional website link, s
 ### 8.12 Mini-Game Activities Admin (v0.5.3)
 
 Admin CRUD at `/admin/activities` for MinuteToWinIt activities (e.g. "Mushroom Kingdom Trivia Showdown", "Yoshi Egg Rescue Relay"). Vicki/Amanda can add, rename, and delete activities. Deletion is blocked if the activity is assigned to a `ScriptedMiniGame`. These are the same activities used by the evening spinner and group assignment overrides on schedule events.
+
+### 8.14 v0.5.5 Feature Set
+
+**Branch:** `feature/118-v055-improvements` | **Issue:** #118
+
+#### 8.14.1 Schedule Improvements
+
+**New event type — Presentation:**
+- `ScheduleEventType.Presentation` added to enum
+- Presenter fields (`PresenterName`, `PresenterBio`) on `ScheduleEvent` are **only shown in admin form and hub view when EventType = Presentation**. On save with any other type, these fields are nulled.
+- In `/hub/schedule`: when EventType = Presentation and PresenterName is set, show presenter name below event title; when PresenterBio is set, show collapsible "About the speaker" section.
+
+**Travel → "Arrival/Departure" display label:**
+- `ScheduleEventType.Travel` keeps its code name (renaming would require a migration + data rewrite).
+- All UI display strings render `Travel` as "Arrival/Departure" — badge in hub view, dropdown label in admin form.
+- Implement via a display helper or switch expression on the enum.
+
+**12-hour time format:**
+- All time display in `/hub/schedule` and `/admin/schedule` uses `h:mm tt` format (e.g. "9:00 AM").
+
+**Data model addition:**
+```
+ScheduleEvent — ... (existing) ..., PresenterName (string?), PresenterBio (string?)
+```
+
+#### 8.14.2 Staff Headshot Photos
+
+- `StaffMember` gets `PhotoData (byte[]?)` + `PhotoContentType (string?)`.
+- Served via `/staff-photo/{id}` endpoint (same streaming pattern as `/sponsor-logo/{id}`).
+- `/hub/staff` card: show `<img>` when photo exists; fall back to `AvatarEmoji` otherwise.
+- Admin staff edit dialog: add `InputFile` photo upload.
+
+#### 8.14.3 Medical Staff Role
+
+- `Role.MedicalStaff` added to enum.
+- Seed: add `MedicalStaff` `UserRole` record in `SeedService`.
+- Permission matrix:
+  - Can log transactions
+  - Can view and acknowledge incident reports (unlike Staff/Volunteer — only submit)
+  - Can view all Hub features (schedule, announcements, staff directory, sponsors, info)
+  - Cannot post/pin announcements, edit info pages, edit staff directory
+  - No access to `/admin/*`
+- User creation/edit dropdown: add `MedicalStaff` option.
+
+#### 8.14.4 Location Images + Board Space Integration
+
+**Location images:**
+- `Location` gets `ImageData (byte[]?)` + `ImageContentType (string?)`.
+- Served via `/location-image/{id}` endpoint.
+- Upload in `/admin/locations` form.
+
+**Activity → Location link (board space integration):**
+- `Activity` gets `LocationId (Guid? FK → Location)` — an activity optionally takes place at a named camp location.
+- `/admin/activities` form: add optional Location dropdown.
+- Board rendering (Board.razor, BoardDisplay.razor): when a board space's activity has a `LocationId` with image data, show the location image on the board space instead of/alongside the activity type icon.
+- EF Core: configure explicit FK to avoid shadow property bug (see Pitfall #13).
+
+#### 8.14.5 Dashboard Landing Page
+
+- `Dashboard.razor` at `/dashboard` — the post-login landing page (replacing `/hub/schedule` as the redirect target from `Index.razor`).
+- Widget layout (neo-brutalist `ccn-panel` sections, Fredoka One headings):
+  1. **Sponsors** (prominent — first widget or largest visual weight; Vicki emphasis): logo tile grid or "View Sponsors" CTA linking to `/hub/sponsors`
+  2. **Today's Schedule**: events for today from `ScheduleService`; time + title; "View Full Schedule" link
+  3. **Latest Announcement**: most recent non-archived, non-expired announcement; title + body preview; "View All" link
+  4. **Quick Nav**: styled nav cards for Schedule, Game Leaderboard, and other key pages
+- Welcome message (camp name + current date).
+- `Index.razor`: change redirect target from `/hub/schedule` to `/dashboard`.
+
+#### 8.14.6 Remove Mini Marios Group
+
+- Remove Group1 (Mini Marios, #E74C3C) from `SeedService.SeedGroupsAsync`.
+- Remaining 3 groups: Blue Shell Bandits (BB, blue), Mushroom Militia (MU, green), Luma Legends (LL, purple).
+- **Production DB note:** `SeedGroupsAsync` purges stale groups on restart. If Mini Marios has FK-referenced rows (transactions, board positions) in the target DB, the purge will fail on a FK constraint. Delete those rows first or handle the purge with a try-catch and log.
+
+#### 8.14.7 Migration
+
+**`AddV055Enhancements`** (single migration or split if simpler):
+- `IncidentReport`: add `IncidentLocationId (uuid nullable FK→Locations)`, `IncidentLocationOther (text nullable)`, `ReportType (int not null default 0)`
+- `StaffMember`: add `PhotoData (bytea nullable)`, `PhotoContentType (text nullable)`
+- `ScheduleEvent`: add `PresenterName (text nullable)`, `PresenterBio (text nullable)`
+- `Sponsor`: add `ContactName (text nullable)`, `Phone (text nullable)`
+- `Location`: add `ImageData (bytea nullable)`, `ImageContentType (text nullable)`
+- `Activity`: add `LocationId (uuid nullable FK→Locations)`
+
+C#-only enum additions (no schema change): `Role.MedicalStaff`, `ScheduleEventType.Presentation`, `IncidentReportType` (new enum in `Enums.cs`).
+
+---
 
 ### 8.13 Shared Dialog Pattern (planned post-v0.5.1)
 

--- a/docs/superpowers/handoffs/2026-06-03-v055-handoff.md
+++ b/docs/superpowers/handoffs/2026-06-03-v055-handoff.md
@@ -1,0 +1,266 @@
+# v0.5.5 Handoff — UI & Service Layer
+
+**Date:** 2026-06-03  
+**Branch:** `feature/118-v055-improvements` (off `dev`)  
+**GitHub issue:** #118  
+**Camp date:** June 20-25, 2026
+
+---
+
+## What's Done
+
+All foundation work is committed and pushed to `feature/118-v055-improvements`:
+
+- **Entities updated:** `IncidentReport`, `StaffMember`, `Sponsor`, `Location`, `Activity`, `ScheduleEvent`
+- **Enums added:** `Role.MedicalStaff`, `IncidentReportType` (Internal/ChildrensHarbor), `ScheduleEventType.Presentation`
+- **AppDbContext:** Explicit FK config for `Activity.LocationId` and `IncidentReport.IncidentLocationId` (Pitfall #13 — always explicit FKs for non-conventional nav property names)
+- **SeedService:** MedicalStaff UserRole + LogTransaction authority; Mini Marios removed; board positions seed uses Group2/3/4 only
+- **Migration:** `20260603051634_AddV055Enhancements` — created and applied to local dev DB
+
+**The DB schema is already in place. All remaining work is UI + service layer.**
+
+---
+
+## Critical Patterns to Follow
+
+Read CLAUDE.md fully before touching any file. Key pitfalls relevant to this work:
+
+- **Never use PowerShell for source file text replacement** — use the Edit tool (Pitfall #1)
+- **Streaming binary endpoints** — follow the exact pattern of `/sponsor-logo/{id}` in `Program.cs` for any new `/staff-photo/{id}` and `/location-image/{id}` endpoints
+- **InputFile upload pattern** — follow `Admin/Sponsors.razor` (it already handles `InputFile` → `byte[]` → entity save)
+- **Modal dialogs** — always use the `fadeIn`/`popIn` pattern from `LogTransactionDialog` (Pitfall #12)
+- **FAB buttons** — always use `ccn-fab-mobile` class (Pitfall #11)
+- **Explicit FK on navigation properties** — already done for new entities; don't add new navigation properties without configuring them in `OnModelCreating`
+- **`[Authorize]` role strings** — use `nameof(Role.X)` or the string `"Admin,MedicalStaff"` as needed; double-check the existing incident page uses the right roles
+
+---
+
+## Remaining Work Items
+
+### 1. Staff Photo Upload + Display
+
+**Files to touch:** `Program.cs`, `Pages/Hub/Staff.razor`, admin staff edit dialog (inline in Staff.razor or a separate component)
+
+**Endpoint (Program.cs):** Add alongside the existing `/sponsor-logo/{id}` endpoint:
+```csharp
+app.MapGet("/staff-photo/{id:guid}", async (Guid id, IDbContextFactory<AppDbContext> factory) =>
+{
+    using var db = factory.CreateDbContext();
+    var member = await db.StaffMembers.FindAsync(id);
+    if (member?.PhotoData is null) return Results.NotFound();
+    return Results.File(member.PhotoData, member.PhotoContentType ?? "image/jpeg");
+}).AllowAnonymous();
+```
+
+**Hub/Staff.razor card:** Where it currently renders `@member.AvatarEmoji`, conditionally show:
+```razor
+@if (member.PhotoData is not null)
+{
+    <img src="/staff-photo/@member.StaffMemberId" style="width:64px;height:64px;object-fit:cover;border-radius:8px;border:2px solid var(--black);" alt="@member.DisplayName" />
+}
+else
+{
+    <span style="font-size:2rem">@member.AvatarEmoji</span>
+}
+```
+
+**Admin upload:** In the admin staff edit dialog (wherever `AvatarEmoji` is currently edited), add:
+```razor
+<InputFile OnChange="HandlePhotoUpload" accept="image/*" />
+```
+With handler that reads the file into `byte[]` and sets `PhotoData`/`PhotoContentType` before save. See `Admin/Sponsors.razor` for the exact `InputFile` pattern already in use.
+
+---
+
+### 2. Sponsor Contact Info Display + Form Fields
+
+**Files:** `Pages/Hub/Sponsors.razor`, `Pages/Admin/Sponsors.razor`
+
+**Hub/Sponsors.razor tile:** Below the sponsor name, add:
+```razor
+@if (!string.IsNullOrEmpty(sponsor.ContactName))
+{
+    <div style="font-size:.8rem;color:var(--black-60)">@sponsor.ContactName</div>
+}
+@if (!string.IsNullOrEmpty(sponsor.Phone))
+{
+    <a href="tel:@sponsor.Phone" style="font-size:.85rem;font-weight:700">@sponsor.Phone</a>
+}
+```
+
+**Admin/Sponsors.razor form:** Add `ContactName` and `Phone` text inputs alongside the existing `Name`, `Website`, `SortOrder` fields. Both nullable.
+
+---
+
+### 3. Sponsor Drag-and-Drop Sort
+
+**File:** `Pages/Admin/Sponsors.razor`
+
+The table rows need HTML5 drag-and-drop. Pattern:
+- Each `<tr>` gets `draggable="true"` and handlers: `@ondragstart`, `@ondragover`, `@ondrop`
+- Track `_dragIndex` (the row being dragged) in component state
+- On drop: reorder the in-memory list, reassign `SortOrder` values (0-based), call `SponsorService.UpdateSortOrderAsync(sponsors)` — you'll need to add this method to `SponsorService`
+
+`SponsorService.UpdateSortOrderAsync`: update each sponsor's `SortOrder` and `SaveChangesAsync`. Use the `AddDbContextFactory` pattern (factory.CreateDbContext()) not a singleton context.
+
+The `/hub/sponsors` page already orders by `SortOrder` — no change needed there.
+
+---
+
+### 4. Incident Report Form — Location + Report Type
+
+**File:** `Pages/Hub/HubSubNav.razor` (contains the Report Incident modal)
+
+**Location field:** Add a `<select>` populated from `LocationService.GetLocationsAsync(eventId)`. Always append an `<option value="">Other</option>` at the end. When "Other" is selected (`_incidentLocationId == null && _showOtherLocation`), reveal a text input bound to `_incidentLocationOther`.
+
+**ReportType field:** Only show to Admin role. Non-admins: `ReportType = IncidentReportType.Internal` set silently. Admins: dropdown with Internal / Children's Harbor options.
+
+**IncidentReportService.SubmitAsync:** Update signature to accept `IncidentLocationId?`, `IncidentLocationOther?`, `ReportType`.
+
+**`/hub/incidents` list:** Add `IncidentLocation` column. Load with `.Include(r => r.IncidentLocation)`. Display: `r.IncidentLocation?.Name ?? (r.IncidentLocationOther is not null ? $"Other: {r.IncidentLocationOther}" : "—")`.
+
+**Print view (`/hub/incidents/{id}/print`):** Show location in the form field, show ReportType in header (e.g. badge: "INTERNAL" or "CHILDREN'S HARBOR").
+
+**Role check on `/hub/incidents`:** Currently `[Authorize(Roles = "Admin")]` or similar. Change to allow `MedicalStaff` as well: `[Authorize(Roles = "Admin,MedicalStaff")]`.
+
+---
+
+### 5. Schedule Improvements
+
+**Files:** `Pages/Hub/Schedule.razor`, `Pages/Admin/Schedule.razor`
+
+**Travel → "Arrival/Departure" display label:**
+Add a helper method (either in a static helper class or inline in both pages):
+```csharp
+private static string DisplayEventType(ScheduleEventType t) => t switch
+{
+    ScheduleEventType.Travel => "Arrival/Departure",
+    _ => t.ToString()
+};
+```
+Use this wherever the event type badge text is rendered.
+
+**12-hour time format:**
+Wherever `StartTime`/`EndTime` are displayed: use `time.ToString("h:mm tt")` instead of `"HH:mm"`. `TimeOnly.ToString("h:mm tt")` works in .NET 6+.
+
+**Presentation event type:**
+- Add `Presentation` to the EventType dropdown in `/admin/schedule` form
+- In the form: show `PresenterName` (text input) and `PresenterBio` (textarea) only when `_form.EventType == ScheduleEventType.Presentation`. Use `@if` conditional.
+- On save: if EventType != Presentation, null out PresenterName and PresenterBio before calling service.
+- In `/hub/schedule` event card: when `EventType == Presentation && PresenterName != null`, show presenter name; when `PresenterBio != null`, show a collapsible "About the speaker" section (simple `<details><summary>` works, or match the existing collapsible pattern in that page).
+
+**ScheduleService.UpsertAsync:** Update to accept/save `PresenterName` and `PresenterBio` from the DTO/model.
+
+---
+
+### 6. Location Images + Board Integration
+
+**Files:** `Program.cs`, `Pages/Admin/Locations.razor`, `Pages/Board.razor`, `Pages/BoardDisplay.razor`, `Services/BoardService.cs`
+
+**Endpoint (Program.cs):**
+```csharp
+app.MapGet("/location-image/{id:guid}", async (Guid id, IDbContextFactory<AppDbContext> factory) =>
+{
+    using var db = factory.CreateDbContext();
+    var loc = await db.Locations.FindAsync(id);
+    if (loc?.ImageData is null) return Results.NotFound();
+    return Results.File(loc.ImageData, loc.ImageContentType ?? "image/jpeg");
+}).AllowAnonymous();
+```
+
+**Admin/Locations.razor:** Add `InputFile` photo upload alongside existing Name/Description/Capacity fields. Same pattern as Sponsors.
+
+**Board rendering:** The board loads `BoardSpace` records. Update `BoardService` (or the query in Board.razor/BoardDisplay.razor) to include:
+```csharp
+.Include(s => s.Activity).ThenInclude(a => a.Location)
+```
+When rendering a board space SVG cell, if `space.Activity?.Location?.ImageData != null`, render:
+```razor
+<image href="/location-image/@space.Activity.Location.LocationId" x="..." y="..." width="..." height="..." />
+```
+as the space background/icon instead of or beneath the activity type icon.
+
+---
+
+### 7. `/admin/activities` — Location Dropdown
+
+**File:** `Pages/Admin/Activities.razor`
+
+Add an optional Location dropdown to the activity form. Load locations from `LocationService.GetLocationsAsync(eventId)`. First option: "— No location —" (null). On save, persist `Activity.LocationId`.
+
+---
+
+### 8. Dashboard Landing Page
+
+**File:** `Pages/Dashboard.razor` (already exists at `/dashboard`), `Pages/Index.razor`
+
+**Index.razor:** Change redirect target from `/hub/schedule` to `/dashboard`.
+
+**Dashboard.razor:** Replace current content with widgets. Use `ccn-panel` CSS class for each widget card (neo-brutalist: black border, 4px shadow offset). Fredoka One headings.
+
+Widget layout (vertical stack on mobile, 2-col grid on desktop):
+
+**Sponsors widget (most prominent — render first or largest):**
+```razor
+<div class="ccn-panel" style="...">
+    <h2 style="font-family:'Fredoka One'">Our Sponsors</h2>
+    @foreach (var sponsor in _sponsors.Take(6))
+    {
+        <img src="/sponsor-logo/@sponsor.SponsorId" style="height:50px;object-fit:contain;margin:4px" />
+    }
+    <a href="/hub/sponsors" class="ccn-btn">View All Sponsors</a>
+</div>
+```
+Load via `SponsorService.GetSponsorsAsync(eventId)`.
+
+**Today's schedule widget:**
+Load `ScheduleService.GetScheduleAsync(eventId)` filtered to today's date (`DateOnly.FromDateTime(DateTime.Today)`). Show up to 5 events: time (12-hour) + title. Link to `/hub/schedule`.
+
+**Latest announcement widget:**
+Load `AnnouncementService.GetActiveAsync(eventId)` and take the first. Show title + truncated body. Link to `/hub/announcements`.
+
+**Quick nav cards:**
+Grid of `<a href="...">` styled as `ccn-panel` buttons: Schedule → `/hub/schedule`, Leaderboard → `/dashboard` (or wherever the leaderboard is), Transactions → `/transactions`.
+
+Inject services via `@inject` and load in `OnInitializedAsync`.
+
+---
+
+### 9. `/admin/users` — Medical Staff Role Option
+
+**File:** `Pages/Admin/Users.razor`
+
+The user create/edit form has a role dropdown. Add `Medical Staff` as an option. The `UserRole` record for MedicalStaff is now seeded with `Id.RoleMedicalStaff`. Load available roles from `db.UserRoles` (already the pattern) — it will automatically include the new role once the seed runs.
+
+---
+
+## Service Layer Note
+
+`IncidentReportService`, `SponsorService`, `LocationService`, `ScheduleService` — all follow the `IDbContextFactory<AppDbContext>` pattern. Any new methods should use `using var db = factory.CreateDbContext()` and not hold the context open. See existing service files for the pattern.
+
+---
+
+## Key Files Reference
+
+| File | Relevance to remaining work |
+|---|---|
+| `Program.cs` | Add `/staff-photo/{id}` and `/location-image/{id}` endpoints |
+| `Pages/Hub/HubSubNav.razor` | Incident report modal — add location + report type fields |
+| `Pages/Hub/Incidents.razor` | Add MedicalStaff role; show location column |
+| `Pages/Hub/IncidentPrint.razor` | Show location + report type |
+| `Pages/Hub/Staff.razor` | Photo display + upload |
+| `Pages/Hub/Sponsors.razor` | Contact info display |
+| `Pages/Admin/Sponsors.razor` | Contact info form fields + drag-and-drop sort |
+| `Pages/Admin/Locations.razor` | Image upload |
+| `Pages/Admin/Activities.razor` | Location dropdown |
+| `Pages/Admin/Schedule.razor` | Presenter fields + Travel label + 12hr time |
+| `Pages/Admin/Users.razor` | Medical Staff role dropdown |
+| `Pages/Hub/Schedule.razor` | Travel label + presenter display + 12hr time |
+| `Pages/Board.razor` | Location image on board spaces |
+| `Pages/BoardDisplay.razor` | Location image on board spaces |
+| `Pages/Dashboard.razor` | Redesign with widgets |
+| `Pages/Index.razor` | Change redirect to /dashboard |
+| `Services/SponsorService.cs` | Add UpdateSortOrderAsync |
+| `Services/IncidentReportService.cs` | Add location + type params to SubmitAsync |
+| `Services/ScheduleService.cs` | Ensure PresenterName/PresenterBio saved by UpsertAsync |
+| `Services/BoardService.cs` | Include Activity.Location in board space queries |


### PR DESCRIPTION
## Summary

Full v0.5.5 feature set. See PR #119 for detailed change notes.

**New features:**
- Staff photo upload and display in hub staff directory
- Sponsor ContactName/Phone with tap-to-call; drag-and-drop sort order
- Incident reports: location picker, Other free-text, Admin-only report type (Internal/Children's Harbor); MedicalStaff role can view/print
- Schedule: Travel → Arrival/Departure display label; new Presentation event type with presenter name/bio fields; 12-hr time format everywhere
- Location images: upload, streaming endpoint, board space renders location image
- Activity → Location association for board image display
- MedicalStaff role: added to seed, Users admin dropdown, and incident access gates

**Dashboard / nav overhaul:**
- New `/dashboard` landing page (sponsors widget, today's schedule, latest announcement, quick nav); replaces `/hub/schedule` as the post-login destination
- Leaderboard moved to `/leaderboard`
- Home tab added to mobile bottom nav
- Board Game nav link gated to Admin + Staff only
- `RedirectToLogin` fixed: authenticated users hitting a role-restricted page go to `/dashboard` instead of `/login` (was appearing as a phantom logout)
- iOS PWA: `env(safe-area-inset-bottom)` added to MainLayout content padding

**Migration:** `20260603051634_AddV055Enhancements` — adds columns to `IncidentReport`, `StaffMember`, `ScheduleEvent`, `Sponsor`, `Location`, `Activity`.

## Test plan

- [ ] Run migration on prod DB before deploying
- [ ] Log in as Admin — lands on `/dashboard`
- [ ] Log in as Volunteer — lands on `/dashboard`, Board Game not in nav
- [ ] Visit `/board` as Volunteer — redirects to `/dashboard`, not login
- [ ] Staff photo upload and display in `/hub/staff`
- [ ] Sponsor drag-and-drop reorders and persists
- [ ] Incident modal: location dropdown + Other free-text; ReportType Admin-only
- [ ] Schedule hub: Travel = Arrival/Departure; Presentation shows presenter info
- [ ] Location image renders on board space
- [ ] iOS PWA: no content hidden under home bar

🤖 Generated with [Claude Code](https://claude.ai/claude-code)