### PR TITLE
feat: v0.5.6 — table-driven schedule types + UX polish

### DIFF
--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -44,8 +44,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<InfoPage> InfoPages => Set<InfoPage>();
     public DbSet<StaffMember> StaffMembers => Set<StaffMember>();
     public DbSet<Announcement> Announcements => Set<Announcement>();
-    public DbSet<ScheduleEvent> ScheduleEvents => Set<ScheduleEvent>();
-    public DbSet<ScheduleEventGroup> ScheduleEventGroups => Set<ScheduleEventGroup>();
+    public DbSet<ScheduleItem> ScheduleItems => Set<ScheduleItem>();
+    public DbSet<ScheduleItemGroup> ScheduleItemGroups => Set<ScheduleItemGroup>();
+    public DbSet<ScheduleItemType> ScheduleItemTypes => Set<ScheduleItemType>();
+    public DbSet<EventScheduleItemType> EventScheduleItemTypes => Set<EventScheduleItemType>();
     public DbSet<IncidentReport> IncidentReports => Set<IncidentReport>();
     public DbSet<Sponsor> Sponsors => Set<Sponsor>();
 
@@ -76,16 +78,36 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         // InfoPage: non-conventional PK (PageId, not InfoPageId)
         modelBuilder.Entity<InfoPage>().HasKey(p => p.PageId);
 
-        // ScheduleEvent: non-conventional PK; CreatedBy is the FK to Users (not the shadow CreatedByUserUserId)
-        modelBuilder.Entity<ScheduleEvent>().HasKey(e => e.ScheduleEventId);
-        modelBuilder.Entity<ScheduleEvent>()
+        // ScheduleItem: explicit PK + FK configs to avoid shadow property bugs
+        modelBuilder.Entity<ScheduleItem>().HasKey(e => e.ScheduleItemId);
+        modelBuilder.Entity<ScheduleItem>()
             .HasOne(e => e.CreatedByUser)
             .WithMany()
             .HasForeignKey(e => e.CreatedBy);
+        modelBuilder.Entity<ScheduleItem>()
+            .HasOne(e => e.ScheduleItemType)
+            .WithMany()
+            .HasForeignKey(e => e.ScheduleItemTypeId);
 
-        // ScheduleEventGroup: composite PK
-        modelBuilder.Entity<ScheduleEventGroup>()
-            .HasKey(eg => new { eg.ScheduleEventId, eg.GroupId });
+        // ScheduleItemGroup: composite PK
+        modelBuilder.Entity<ScheduleItemGroup>()
+            .HasKey(eg => new { eg.ScheduleItemId, eg.GroupId });
+        modelBuilder.Entity<ScheduleItemGroup>()
+            .HasOne(eg => eg.ScheduleItem)
+            .WithMany(e => e.ItemGroups)
+            .HasForeignKey(eg => eg.ScheduleItemId);
+
+        // EventScheduleItemType: composite PK + FK configs
+        modelBuilder.Entity<EventScheduleItemType>()
+            .HasKey(e => new { e.EventId, e.ScheduleItemTypeId });
+        modelBuilder.Entity<EventScheduleItemType>()
+            .HasOne(e => e.Event)
+            .WithMany()
+            .HasForeignKey(e => e.EventId);
+        modelBuilder.Entity<EventScheduleItemType>()
+            .HasOne(e => e.ScheduleItemType)
+            .WithMany()
+            .HasForeignKey(e => e.ScheduleItemTypeId);
 
         // InfoPage: unique index on Slug
         modelBuilder.Entity<InfoPage>()

--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -88,6 +88,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .HasOne(e => e.ScheduleItemType)
             .WithMany()
             .HasForeignKey(e => e.ScheduleItemTypeId);
+        modelBuilder.Entity<ScheduleItem>()
+            .HasOne(e => e.Activity)
+            .WithMany()
+            .HasForeignKey(e => e.ActivityId);
 
         // ScheduleItemGroup: composite PK
         modelBuilder.Entity<ScheduleItemGroup>()

--- a/CampClotNot/Data/Entities/EventScheduleItemType.cs
+++ b/CampClotNot/Data/Entities/EventScheduleItemType.cs
@@ -1,0 +1,9 @@
+namespace CampClotNot.Data.Entities;
+
+public class EventScheduleItemType
+{
+    public Guid EventId { get; set; }
+    public Event Event { get; set; } = null!;
+    public Guid ScheduleItemTypeId { get; set; }
+    public ScheduleItemType ScheduleItemType { get; set; } = null!;
+}

--- a/CampClotNot/Data/Entities/ScheduleEvent.cs
+++ b/CampClotNot/Data/Entities/ScheduleEvent.cs
@@ -1,11 +1,9 @@
 namespace CampClotNot.Data.Entities;
 
-public enum ScheduleEventType { Activity, Meal, Travel, Free, Mandatory, Presentation }
-
-public class ScheduleEvent
+public class ScheduleItem
 {
-    public Guid ScheduleEventId { get; set; }
-    public Guid CampEventId { get; set; }       // FK to Event — scopes to CCN 2026
+    public Guid ScheduleItemId { get; set; }
+    public Guid CampEventId { get; set; }
     public Event CampEvent { get; set; } = null!;
     public DateOnly CampDay { get; set; }
     public TimeOnly StartTime { get; set; }
@@ -14,13 +12,14 @@ public class ScheduleEvent
     public string? Description { get; set; }
     public Guid? LocationId { get; set; }
     public Location? Location { get; set; }
-    public ScheduleEventType EventType { get; set; }
+    public Guid ScheduleItemTypeId { get; set; }
+    public ScheduleItemType ScheduleItemType { get; set; } = null!;
     public string? PresenterName { get; set; }
     public string? PresenterBio { get; set; }
     public bool AppliesToAllGroups { get; set; } = true;
-    public int? MaxCapacity { get; set; }       // stored silently; future registration feature
+    public int? MaxCapacity { get; set; }
     public Guid CreatedBy { get; set; }
     public User CreatedByUser { get; set; } = null!;
     public DateTime UpdatedAt { get; set; }
-    public List<ScheduleEventGroup> EventGroups { get; set; } = new();
+    public List<ScheduleItemGroup> ItemGroups { get; set; } = new();
 }

--- a/CampClotNot/Data/Entities/ScheduleEvent.cs
+++ b/CampClotNot/Data/Entities/ScheduleEvent.cs
@@ -12,6 +12,9 @@ public class ScheduleItem
     public string? Description { get; set; }
     public Guid? LocationId { get; set; }
     public Location? Location { get; set; }
+    public string? LocationOther { get; set; }
+    public Guid? ActivityId { get; set; }
+    public Activity? Activity { get; set; }
     public Guid ScheduleItemTypeId { get; set; }
     public ScheduleItemType ScheduleItemType { get; set; } = null!;
     public string? PresenterName { get; set; }

--- a/CampClotNot/Data/Entities/ScheduleEventGroup.cs
+++ b/CampClotNot/Data/Entities/ScheduleEventGroup.cs
@@ -1,9 +1,9 @@
 namespace CampClotNot.Data.Entities;
 
-public class ScheduleEventGroup
+public class ScheduleItemGroup
 {
-    public Guid ScheduleEventId { get; set; }
-    public ScheduleEvent ScheduleEvent { get; set; } = null!;
+    public Guid ScheduleItemId { get; set; }
+    public ScheduleItem ScheduleItem { get; set; } = null!;
     public Guid GroupId { get; set; }
     public Group Group { get; set; } = null!;
     public Guid? ActivityId { get; set; }

--- a/CampClotNot/Data/Entities/ScheduleItemType.cs
+++ b/CampClotNot/Data/Entities/ScheduleItemType.cs
@@ -1,0 +1,10 @@
+namespace CampClotNot.Data.Entities;
+
+public class ScheduleItemType
+{
+    public Guid ScheduleItemTypeId { get; set; }
+    public string Name { get; set; } = "";
+    public string SystemName { get; set; } = "";
+    public string? Description { get; set; }
+    public int SortOrder { get; set; }
+}

--- a/CampClotNot/Data/Entities/StaffMember.cs
+++ b/CampClotNot/Data/Entities/StaffMember.cs
@@ -11,6 +11,7 @@ public class StaffMember
     public string? Email { get; set; }
     public byte[]? PhotoData { get; set; }
     public string? PhotoContentType { get; set; }
+    public string? PhotoObjectPosition { get; set; }
     public string AvatarEmoji { get; set; } = "👤";
     public bool IsVisible { get; set; } = true;
     public int SortOrder { get; set; }

--- a/CampClotNot/Migrations/20260603233533_AddV056ScheduleItemTypes.Designer.cs
+++ b/CampClotNot/Migrations/20260603233533_AddV056ScheduleItemTypes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603233533_AddV056ScheduleItemTypes")]
+    partial class AddV056ScheduleItemTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260603233533_AddV056ScheduleItemTypes.cs
+++ b/CampClotNot/Migrations/20260603233533_AddV056ScheduleItemTypes.cs
@@ -1,0 +1,429 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddV056ScheduleItemTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // ── 1. Create ScheduleItemTypes table ─────────────────────────────
+            migrationBuilder.CreateTable(
+                name: "ScheduleItemTypes",
+                columns: table => new
+                {
+                    ScheduleItemTypeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name               = table.Column<string>(type: "text", nullable: false),
+                    SystemName         = table.Column<string>(type: "text", nullable: false),
+                    Description        = table.Column<string>(type: "text", nullable: true),
+                    SortOrder          = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScheduleItemTypes", x => x.ScheduleItemTypeId);
+                });
+
+            // ── 2. Seed six stable ScheduleItemType rows (used in data migration below) ──
+            migrationBuilder.Sql(@"
+                INSERT INTO ""ScheduleItemTypes"" (""ScheduleItemTypeId"", ""Name"", ""SystemName"", ""Description"", ""SortOrder"") VALUES
+                ('0000000f-000f-000f-000f-000000000001', 'Activity',     'Activity',     'Scheduled camp activity',        1),
+                ('0000000f-000f-000f-000f-000000000002', 'Meal',         'Meal',         'Breakfast, lunch, or dinner',    2),
+                ('0000000f-000f-000f-000f-000000000003', 'Travel',       'Travel',       'Arrival or departure',           3),
+                ('0000000f-000f-000f-000f-000000000004', 'Free Time',    'Free',         'Unstructured free time',         4),
+                ('0000000f-000f-000f-000f-000000000005', 'Mandatory',    'Mandatory',    'All-group required session',     5),
+                ('0000000f-000f-000f-000f-000000000006', 'Presentation', 'Presentation', 'Speaker or educational session', 6)
+                ON CONFLICT DO NOTHING;
+            ");
+
+            // ── 3. Create EventScheduleItemTypes join table ───────────────────
+            migrationBuilder.CreateTable(
+                name: "EventScheduleItemTypes",
+                columns: table => new
+                {
+                    EventId            = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScheduleItemTypeId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventScheduleItemTypes", x => new { x.EventId, x.ScheduleItemTypeId });
+                    table.ForeignKey(
+                        name: "FK_EventScheduleItemTypes_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "EventId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EventScheduleItemTypes_ScheduleItemTypes_ScheduleItemTypeId",
+                        column: x => x.ScheduleItemTypeId,
+                        principalTable: "ScheduleItemTypes",
+                        principalColumn: "ScheduleItemTypeId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            // ── 4. Seed CCN 2026 event with all six types ─────────────────────
+            migrationBuilder.Sql(@"
+                INSERT INTO ""EventScheduleItemTypes"" (""EventId"", ""ScheduleItemTypeId"") VALUES
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000001'),
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000002'),
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000003'),
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000004'),
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000005'),
+                ('00000009-0009-0009-0009-000000000001', '0000000f-000f-000f-000f-000000000006')
+                ON CONFLICT DO NOTHING;
+            ");
+
+            // ── 5. Drop FKs/indexes on ScheduleEventGroups before table rename ─
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEventGroups_Activities_ActivityId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEventGroups_Groups_GroupId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEventGroups_Locations_LocationId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEventGroups_ScheduleEvents_ScheduleEventId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEventGroups_ActivityId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEventGroups_GroupId",
+                table: "ScheduleEventGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEventGroups_LocationId",
+                table: "ScheduleEventGroups");
+
+            // ── 6. Drop FKs/indexes on ScheduleEvents before table rename ─────
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEvents_Events_CampEventId",
+                table: "ScheduleEvents");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEvents_Locations_LocationId",
+                table: "ScheduleEvents");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedBy",
+                table: "ScheduleEvents");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEvents_CampEventId",
+                table: "ScheduleEvents");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEvents_CreatedBy",
+                table: "ScheduleEvents");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleEvents_LocationId",
+                table: "ScheduleEvents");
+
+            // ── 7. Rename tables ──────────────────────────────────────────────
+            migrationBuilder.RenameTable(
+                name: "ScheduleEvents",
+                newName: "ScheduleItems");
+            migrationBuilder.RenameTable(
+                name: "ScheduleEventGroups",
+                newName: "ScheduleItemGroups");
+
+            // ── 8. Rename PK columns ──────────────────────────────────────────
+            migrationBuilder.RenameColumn(
+                name: "ScheduleEventId",
+                table: "ScheduleItems",
+                newName: "ScheduleItemId");
+            migrationBuilder.RenameColumn(
+                name: "ScheduleEventId",
+                table: "ScheduleItemGroups",
+                newName: "ScheduleItemId");
+
+            // ── 9. Add ScheduleItemTypeId (nullable — filled in data migration) ─
+            migrationBuilder.AddColumn<Guid>(
+                name: "ScheduleItemTypeId",
+                table: "ScheduleItems",
+                type: "uuid",
+                nullable: true);
+
+            // ── 10. Map old EventType int values to new ScheduleItemTypeId GUIDs ─
+            // Activity=0, Meal=1, Travel=2, Free=3, Mandatory=4, Presentation=5
+            migrationBuilder.Sql(@"
+                UPDATE ""ScheduleItems"" SET ""ScheduleItemTypeId"" = CASE ""EventType""
+                    WHEN 0 THEN '0000000f-000f-000f-000f-000000000001'::uuid
+                    WHEN 1 THEN '0000000f-000f-000f-000f-000000000002'::uuid
+                    WHEN 2 THEN '0000000f-000f-000f-000f-000000000003'::uuid
+                    WHEN 3 THEN '0000000f-000f-000f-000f-000000000004'::uuid
+                    WHEN 4 THEN '0000000f-000f-000f-000f-000000000005'::uuid
+                    WHEN 5 THEN '0000000f-000f-000f-000f-000000000006'::uuid
+                    ELSE        '0000000f-000f-000f-000f-000000000001'::uuid
+                END
+            ");
+
+            // ── 11. Make ScheduleItemTypeId NOT NULL ──────────────────────────
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ScheduleItemTypeId",
+                table: "ScheduleItems",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            // ── 12. Drop old EventType column ─────────────────────────────────
+            migrationBuilder.DropColumn(
+                name: "EventType",
+                table: "ScheduleItems");
+
+            // ── 13. Recreate ScheduleItems FKs and indexes with new names ─────
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItems_Events_CampEventId",
+                table: "ScheduleItems",
+                column: "CampEventId",
+                principalTable: "Events",
+                principalColumn: "EventId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItems_Locations_LocationId",
+                table: "ScheduleItems",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItems_Users_CreatedBy",
+                table: "ScheduleItems",
+                column: "CreatedBy",
+                principalTable: "Users",
+                principalColumn: "UserId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItems_ScheduleItemTypes_ScheduleItemTypeId",
+                table: "ScheduleItems",
+                column: "ScheduleItemTypeId",
+                principalTable: "ScheduleItemTypes",
+                principalColumn: "ScheduleItemTypeId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItems_CampEventId",
+                table: "ScheduleItems",
+                column: "CampEventId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItems_CreatedBy",
+                table: "ScheduleItems",
+                column: "CreatedBy");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItems_LocationId",
+                table: "ScheduleItems",
+                column: "LocationId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItems_ScheduleItemTypeId",
+                table: "ScheduleItems",
+                column: "ScheduleItemTypeId");
+
+            // ── 14. Recreate ScheduleItemGroups FKs and indexes with new names ─
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItemGroups_Activities_ActivityId",
+                table: "ScheduleItemGroups",
+                column: "ActivityId",
+                principalTable: "Activities",
+                principalColumn: "ActivityId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItemGroups_Groups_GroupId",
+                table: "ScheduleItemGroups",
+                column: "GroupId",
+                principalTable: "Groups",
+                principalColumn: "GroupId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItemGroups_Locations_LocationId",
+                table: "ScheduleItemGroups",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItemGroups_ScheduleItems_ScheduleItemId",
+                table: "ScheduleItemGroups",
+                column: "ScheduleItemId",
+                principalTable: "ScheduleItems",
+                principalColumn: "ScheduleItemId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItemGroups_ActivityId",
+                table: "ScheduleItemGroups",
+                column: "ActivityId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItemGroups_GroupId",
+                table: "ScheduleItemGroups",
+                column: "GroupId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItemGroups_LocationId",
+                table: "ScheduleItemGroups",
+                column: "LocationId");
+
+            // ── 15. Index for EventScheduleItemTypes ──────────────────────────
+            migrationBuilder.CreateIndex(
+                name: "IX_EventScheduleItemTypes_ScheduleItemTypeId",
+                table: "EventScheduleItemTypes",
+                column: "ScheduleItemTypeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Drop new FKs and indexes
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItemGroups_Activities_ActivityId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItemGroups_Groups_GroupId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItemGroups_Locations_LocationId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItemGroups_ScheduleItems_ScheduleItemId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItemGroups_ActivityId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItemGroups_GroupId",
+                table: "ScheduleItemGroups");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItemGroups_LocationId",
+                table: "ScheduleItemGroups");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItems_Events_CampEventId",
+                table: "ScheduleItems");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItems_Locations_LocationId",
+                table: "ScheduleItems");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItems_Users_CreatedBy",
+                table: "ScheduleItems");
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItems_ScheduleItemTypes_ScheduleItemTypeId",
+                table: "ScheduleItems");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItems_CampEventId",
+                table: "ScheduleItems");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItems_CreatedBy",
+                table: "ScheduleItems");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItems_LocationId",
+                table: "ScheduleItems");
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItems_ScheduleItemTypeId",
+                table: "ScheduleItems");
+
+            // Drop ScheduleItemTypeId, restore EventType column
+            migrationBuilder.DropColumn(
+                name: "ScheduleItemTypeId",
+                table: "ScheduleItems");
+            migrationBuilder.AddColumn<int>(
+                name: "EventType",
+                table: "ScheduleItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // Rename columns back
+            migrationBuilder.RenameColumn(
+                name: "ScheduleItemId",
+                table: "ScheduleItems",
+                newName: "ScheduleEventId");
+            migrationBuilder.RenameColumn(
+                name: "ScheduleItemId",
+                table: "ScheduleItemGroups",
+                newName: "ScheduleEventId");
+
+            // Rename tables back
+            migrationBuilder.RenameTable(
+                name: "ScheduleItems",
+                newName: "ScheduleEvents");
+            migrationBuilder.RenameTable(
+                name: "ScheduleItemGroups",
+                newName: "ScheduleEventGroups");
+
+            // Recreate old FKs and indexes
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEvents_Events_CampEventId",
+                table: "ScheduleEvents",
+                column: "CampEventId",
+                principalTable: "Events",
+                principalColumn: "EventId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEvents_Locations_LocationId",
+                table: "ScheduleEvents",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEvents_Users_CreatedBy",
+                table: "ScheduleEvents",
+                column: "CreatedBy",
+                principalTable: "Users",
+                principalColumn: "UserId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEvents_CampEventId",
+                table: "ScheduleEvents",
+                column: "CampEventId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEvents_CreatedBy",
+                table: "ScheduleEvents",
+                column: "CreatedBy");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEvents_LocationId",
+                table: "ScheduleEvents",
+                column: "LocationId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEventGroups_Activities_ActivityId",
+                table: "ScheduleEventGroups",
+                column: "ActivityId",
+                principalTable: "Activities",
+                principalColumn: "ActivityId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEventGroups_Groups_GroupId",
+                table: "ScheduleEventGroups",
+                column: "GroupId",
+                principalTable: "Groups",
+                principalColumn: "GroupId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEventGroups_Locations_LocationId",
+                table: "ScheduleEventGroups",
+                column: "LocationId",
+                principalTable: "Locations",
+                principalColumn: "LocationId");
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleEventGroups_ScheduleEvents_ScheduleEventId",
+                table: "ScheduleEventGroups",
+                column: "ScheduleEventId",
+                principalTable: "ScheduleEvents",
+                principalColumn: "ScheduleEventId",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEventGroups_ActivityId",
+                table: "ScheduleEventGroups",
+                column: "ActivityId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEventGroups_GroupId",
+                table: "ScheduleEventGroups",
+                column: "GroupId");
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleEventGroups_LocationId",
+                table: "ScheduleEventGroups",
+                column: "LocationId");
+
+            migrationBuilder.DropTable(
+                name: "EventScheduleItemTypes");
+            migrationBuilder.DropTable(
+                name: "ScheduleItemTypes");
+        }
+    }
+}

--- a/CampClotNot/Migrations/20260604001727_AddScheduleItemActivity.Designer.cs
+++ b/CampClotNot/Migrations/20260604001727_AddScheduleItemActivity.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604001727_AddScheduleItemActivity")]
+    partial class AddScheduleItemActivity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -625,9 +628,6 @@ namespace CampClotNot.Migrations
                     b.Property<Guid?>("LocationId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("LocationOther")
-                        .HasColumnType("text");
-
                     b.Property<int?>("MaxCapacity")
                         .HasColumnType("integer");
 
@@ -850,9 +850,6 @@ namespace CampClotNot.Migrations
 
                     b.Property<byte[]>("PhotoData")
                         .HasColumnType("bytea");
-
-                    b.Property<string>("PhotoObjectPosition")
-                        .HasColumnType("text");
 
                     b.Property<string>("RoleTitle")
                         .IsRequired()

--- a/CampClotNot/Migrations/20260604001727_AddScheduleItemActivity.cs
+++ b/CampClotNot/Migrations/20260604001727_AddScheduleItemActivity.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScheduleItemActivity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ActivityId",
+                table: "ScheduleItems",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleItems_ActivityId",
+                table: "ScheduleItems",
+                column: "ActivityId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ScheduleItems_Activities_ActivityId",
+                table: "ScheduleItems",
+                column: "ActivityId",
+                principalTable: "Activities",
+                principalColumn: "ActivityId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ScheduleItems_Activities_ActivityId",
+                table: "ScheduleItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ScheduleItems_ActivityId",
+                table: "ScheduleItems");
+
+            migrationBuilder.DropColumn(
+                name: "ActivityId",
+                table: "ScheduleItems");
+        }
+    }
+}

--- a/CampClotNot/Migrations/20260604003957_AddStaffPhotoObjectPosition.Designer.cs
+++ b/CampClotNot/Migrations/20260604003957_AddStaffPhotoObjectPosition.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604003957_AddStaffPhotoObjectPosition")]
+    partial class AddStaffPhotoObjectPosition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -624,9 +627,6 @@ namespace CampClotNot.Migrations
 
                     b.Property<Guid?>("LocationId")
                         .HasColumnType("uuid");
-
-                    b.Property<string>("LocationOther")
-                        .HasColumnType("text");
 
                     b.Property<int?>("MaxCapacity")
                         .HasColumnType("integer");

--- a/CampClotNot/Migrations/20260604003957_AddStaffPhotoObjectPosition.cs
+++ b/CampClotNot/Migrations/20260604003957_AddStaffPhotoObjectPosition.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStaffPhotoObjectPosition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PhotoObjectPosition",
+                table: "StaffMembers",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PhotoObjectPosition",
+                table: "StaffMembers");
+        }
+    }
+}

--- a/CampClotNot/Migrations/20260604004934_AddScheduleItemLocationOther.Designer.cs
+++ b/CampClotNot/Migrations/20260604004934_AddScheduleItemLocationOther.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604004934_AddScheduleItemLocationOther")]
+    partial class AddScheduleItemLocationOther
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260604004934_AddScheduleItemLocationOther.cs
+++ b/CampClotNot/Migrations/20260604004934_AddScheduleItemLocationOther.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScheduleItemLocationOther : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LocationOther",
+                table: "ScheduleItems",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LocationOther",
+                table: "ScheduleItems");
+        }
+    }
+}

--- a/CampClotNot/Pages/Admin/Locations.razor
+++ b/CampClotNot/Pages/Admin/Locations.razor
@@ -35,28 +35,20 @@
                 }
                 @if (_fImageData is not null)
                 {
-                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">✅ File ready to upload</div>
+                    <img src="data:@_fImageContentType;base64,@Convert.ToBase64String(_fImageData)"
+                         style="display:block;max-width:100%;max-height:120px;object-fit:contain;border:2px solid var(--black);border-radius:6px;margin-top:8px" alt="Preview" />
                 }
-                else if (_currentHasImage)
+                else if (_currentHasImage && _editingId != Guid.Empty)
                 {
-                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">Current: uploaded image (leave blank to keep)</div>
+                    <img src="/location-image/@_editingId"
+                         style="display:block;max-width:100%;max-height:120px;object-fit:contain;border:2px solid var(--black);border-radius:6px;margin-top:8px" alt="Current image" />
                 }
             </div>
 
-            <div style="display:flex;gap:10px;margin-bottom:16px">
-                <div style="flex:1">
-                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Capacity</div>
-                    <input type="number" min="0"
-                           value="@(_fCapacity?.ToString() ?? "")"
-                           @onchange="e => _fCapacity = int.TryParse(e.Value?.ToString(), out var v) ? v : null"
-                           placeholder="—"
-                           style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
-                </div>
-                <div style="flex:1">
-                    <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Sort Order</div>
-                    <input type="number" @bind="_fSortOrder"
-                           style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
-                </div>
+            <div style="margin-bottom:16px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Sort Order</div>
+                <input type="number" @bind="_fSortOrder"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
             </div>
 
             <div style="display:flex;gap:8px">
@@ -86,7 +78,7 @@
                             <tr style="background:var(--black)">
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Description</th>
-                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Capacity</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Image</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Order</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                             </tr>
@@ -97,7 +89,19 @@
                                 <tr style="border-bottom:2px solid #E8E0CC">
                                     <td style="padding:10px 14px;font-size:13px;font-weight:700">@loc.Name</td>
                                     <td style="padding:10px 14px;font-size:13px;color:var(--text-mid)">@(loc.Description ?? "—")</td>
-                                    <td style="padding:10px 14px;font-size:13px">@(loc.Capacity?.ToString() ?? "—")</td>
+                                    <td style="padding:6px 10px">
+                                        @if (loc.ImageData is not null)
+                                        {
+                                            <img src="/location-image/@loc.LocationId"
+                                                 style="width:56px;height:40px;object-fit:cover;border-radius:4px;border:2px solid var(--black);cursor:zoom-in"
+                                                 alt="@loc.Name"
+                                                 @onclick='() => _lightboxSrc = $"/location-image/{loc.LocationId}"' />
+                                        }
+                                        else
+                                        {
+                                            <span style="font-size:12px;color:var(--text-light)">—</span>
+                                        }
+                                    </td>
                                     <td style="padding:10px 14px;font-size:13px">@loc.SortOrder</td>
                                     <td style="padding:8px 10px">
                                         <div style="display:flex;gap:4px">
@@ -116,9 +120,22 @@
     </div>
 </div>
 
+@if (_lightboxSrc is not null)
+{
+    <div style="position:fixed;inset:0;background:rgba(26,26,26,.85);z-index:200;display:flex;align-items:center;justify-content:center;animation:fadeIn .15s ease;cursor:zoom-out"
+         @onclick="() => _lightboxSrc = null">
+        <img src="@_lightboxSrc"
+             style="max-width:92vw;max-height:88vh;object-fit:contain;border:3px solid var(--black);border-radius:10px;box-shadow:6px 6px 0 var(--black);animation:popIn .2s ease"
+             alt="Location image" @onclick:stopPropagation />
+        <button style="position:fixed;top:16px;right:20px;background:none;border:none;color:white;font-size:28px;cursor:pointer;line-height:1"
+                @onclick="() => _lightboxSrc = null">✕</button>
+    </div>
+}
+
 @code {
     private List<Location> _locations = new();
     private bool _loading = true;
+    private string? _lightboxSrc;
     private Guid _editingId;
     private string _fName = "";
     private string? _fDescription;

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -37,14 +37,12 @@
             <div style="display:flex;gap:10px;margin-bottom:14px">
                 <div style="flex:1">
                     <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Start</div>
-                    <input type="time" value="@_fStartStr"
-                           @onchange="e => _fStartStr = e.Value?.ToString() ?? string.Empty"
+                    <input type="text" @bind="_fStartStr" placeholder="9:30 AM"
                            style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
                 </div>
                 <div style="flex:1">
                     <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">End (optional)</div>
-                    <input type="time" value="@_fEndStr"
-                           @onchange="e => _fEndStr = e.Value?.ToString() ?? string.Empty"
+                    <input type="text" @bind="_fEndStr" placeholder="10:30 AM"
                            style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
                 </div>
             </div>
@@ -89,9 +87,28 @@
             </div>
 
             <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Additional location / other (optional)</div>
+                <input type="text" @bind="_fLocationOther" placeholder="e.g. Gym + Pool deck"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Description (optional)</div>
                 <input type="text" @bind="_fDesc" placeholder="Short description"
                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Activity (optional)</div>
+                <select value="@(_fActivityId?.ToString() ?? "")"
+                        @onchange="e => _fActivityId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : null"
+                        style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
+                    <option value="">— N/A —</option>
+                    @foreach (var act in _activities)
+                    {
+                        <option value="@act.ActivityId">@act.Name</option>
+                    }
+                </select>
             </div>
 
             @* ── Group Assignments ── *@
@@ -225,7 +242,18 @@
                                             @DisplayItemType(ev.ScheduleItemType)
                                         </span>
                                     </td>
-                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid)">@(ev.Location?.Name ?? "—")</td>
+                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid)">
+                        @if (ev.Location is not null || !string.IsNullOrEmpty(ev.LocationOther))
+                        {
+                            @(ev.Location?.Name ?? "")
+                            @if (ev.Location is not null && !string.IsNullOrEmpty(ev.LocationOther)) { <span> + </span> }
+                            @(ev.LocationOther ?? "")
+                        }
+                        else
+                        {
+                            <span>—</span>
+                        }
+                    </td>
                                     <td style="padding:8px 10px">
                                         <div style="display:flex;gap:4px">
                                             <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(ev)">Edit</button>
@@ -259,6 +287,8 @@
     private string _fEndStr = "";
     private Guid _fTypeId;
     private Guid? _fLocationId;
+    private string? _fLocationOther;
+    private Guid? _fActivityId;
     private string? _fDesc;
     private string? _fPresenterName;
     private string? _fPresenterBio;
@@ -317,11 +347,13 @@
         _editingId      = ev.ScheduleItemId;
         _fTitle         = ev.Title;
         _fDesc          = ev.Description;
-        _fDateStr       = ev.CampDay.ToString("yyyy-MM-dd");
-        _fStartStr      = ev.StartTime.ToString("HH:mm");
-        _fEndStr        = ev.EndTime?.ToString("HH:mm") ?? "";
+        _fDateStr  = ev.CampDay.ToString("yyyy-MM-dd");
+        _fStartStr = ev.StartTime.ToString("h:mm tt");
+        _fEndStr   = ev.EndTime?.ToString("h:mm tt") ?? "";
         _fTypeId        = ev.ScheduleItemTypeId;
         _fLocationId    = ev.LocationId;
+        _fLocationOther = ev.LocationOther;
+        _fActivityId    = ev.ActivityId;
         _fPresenterName = ev.PresenterName;
         _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
@@ -344,11 +376,13 @@
         _editingId           = Guid.Empty;
         _fTitle              = "";
         _fDesc               = null;
-        _fDateStr            = _minDate;
-        _fStartStr           = "";
-        _fEndStr             = "";
+        _fDateStr  = _minDate;
+        _fStartStr = "";
+        _fEndStr   = "";
         _fTypeId             = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
         _fLocationId         = null;
+        _fLocationOther      = null;
+        _fActivityId         = null;
         _fPresenterName      = null;
         _fPresenterBio       = null;
         _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
@@ -363,10 +397,11 @@
         if (string.IsNullOrWhiteSpace(_fDateStr))  { _error = "Day is required."; return; }
         if (string.IsNullOrWhiteSpace(_fStartStr)) { _error = "Start time is required."; return; }
         if (_fTypeId == Guid.Empty)                { _error = "Type is required."; return; }
-        if (!DateOnly.TryParseExact(_fDateStr,  "yyyy-MM-dd", out var day))   { _error = "Invalid date."; return; }
-        if (!TimeOnly.TryParseExact(_fStartStr, "HH:mm", out var start))      { _error = "Invalid start time."; return; }
-        TimeOnly? end = string.IsNullOrEmpty(_fEndStr) ? null
-            : TimeOnly.TryParseExact(_fEndStr, "HH:mm", out var et) ? et : null;
+        if (!DateOnly.TryParseExact(_fDateStr, "yyyy-MM-dd", out var day)) { _error = "Invalid date."; return; }
+        if (!DateTime.TryParse(_fStartStr, out var startDt)) { _error = "Invalid start time — try \"9:30 AM\"."; return; }
+        var start = TimeOnly.FromDateTime(startDt);
+        TimeOnly? end = string.IsNullOrWhiteSpace(_fEndStr) ? null
+            : DateTime.TryParse(_fEndStr, out var endDt) ? TimeOnly.FromDateTime(endDt) : null;
 
         var assignments = _fAssignments
             .Where(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note))
@@ -379,11 +414,12 @@
             SeedService.Id.EventCcn2026,
             day, start, end,
             _fTitle.Trim(), _fDesc,
-            _fLocationId, _fTypeId,
+            _fLocationId, _fActivityId, _fTypeId,
             !assignments.Any(),
             null, assignments,
             isPresentation ? _fPresenterName : null,
-            isPresentation ? _fPresenterBio  : null
+            isPresentation ? _fPresenterBio  : null,
+            string.IsNullOrWhiteSpace(_fLocationOther) ? null : _fLocationOther.Trim()
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
         Snackbar.Add(_editingId == Guid.Empty ? $"{_fTitle} added." : $"{_fTitle} updated.", Severity.Success);
@@ -398,8 +434,7 @@
         await Reload();
     }
 
-    private static string DisplayItemType(ScheduleItemType? t) =>
-        t?.SystemName == "Travel" ? "Arrival/Departure" : (t?.Name ?? "—");
+    private static string DisplayItemType(ScheduleItemType? t) => t?.Name ?? "—";
 
     private static string ItemTypeBadgeColor(string? systemName) => systemName switch
     {

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -1,6 +1,7 @@
 @page "/admin/schedule"
 @attribute [Authorize(Roles = "Admin")]
 @inject ScheduleService ScheduleSvc
+@inject ScheduleItemTypeService ScheduleItemTypeSvc
 @inject LocationService LocationSvc
 @inject MiniGameService MiniGameSvc
 @inject IDbContextFactory<AppDbContext> DbFactory
@@ -50,16 +51,17 @@
 
             <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Type</div>
-                <select @bind="_fType"
+                <select value="@_fTypeId.ToString()"
+                        @onchange="e => _fTypeId = Guid.TryParse(e.Value?.ToString(), out var v) ? v : _fTypeId"
                         style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box">
-                    @foreach (var t in Enum.GetValues<ScheduleEventType>())
+                    @foreach (var t in _scheduleItemTypes)
                     {
-                        <option value="@t">@DisplayEventType(t)</option>
+                        <option value="@t.ScheduleItemTypeId">@DisplayItemType(t)</option>
                     }
                 </select>
             </div>
 
-            @if (_fType == ScheduleEventType.Presentation)
+            @if (SelectedTypeSystemName == "Presentation")
             {
                 <div style="margin-bottom:14px">
                     <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Presenter Name</div>
@@ -213,14 +215,14 @@
                                         {
                                             <div style="font-size:11px;color:var(--text-light)">@ev.Description</div>
                                         }
-                                        @if (ev.EventGroups.Any())
+                                        @if (ev.ItemGroups.Any())
                                         {
-                                            <div style="font-size:11px;color:var(--text-light)">@ev.EventGroups.Count group assign.</div>
+                                            <div style="font-size:11px;color:var(--text-light)">@ev.ItemGroups.Count group assign.</div>
                                         }
                                     </td>
                                     <td style="padding:8px 14px">
-                                        <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
-                                            @DisplayEventType(ev.EventType)
+                                        <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@ItemTypeBadgeColor(ev.ScheduleItemType?.SystemName);color:white;font-family:'Fredoka One',cursive">
+                                            @DisplayItemType(ev.ScheduleItemType)
                                         </span>
                                     </td>
                                     <td style="padding:8px 14px;font-size:12px;color:var(--text-mid)">@(ev.Location?.Name ?? "—")</td>
@@ -242,7 +244,8 @@
 </div>
 
 @code {
-    private List<ScheduleEvent> _events = new();
+    private List<ScheduleItem> _events = new();
+    private List<ScheduleItemType> _scheduleItemTypes = new();
     private List<Location> _locations = new();
     private List<Activity> _activities = new();
     private List<Group> _groups = new();
@@ -254,7 +257,7 @@
     private string _fDateStr = "";
     private string _fStartStr = "";
     private string _fEndStr = "";
-    private ScheduleEventType _fType = ScheduleEventType.Activity;
+    private Guid _fTypeId;
     private Guid? _fLocationId;
     private string? _fDesc;
     private string? _fPresenterName;
@@ -265,6 +268,9 @@
 
     private string _minDate = "";
     private string _maxDate = "";
+
+    private string? SelectedTypeSystemName =>
+        _scheduleItemTypes.FirstOrDefault(t => t.ScheduleItemTypeId == _fTypeId)?.SystemName;
 
     private int _assignedCount =>
         _fAssignments.Count(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note));
@@ -282,6 +288,9 @@
             _maxDate  = campEvent.ExpDate.ToString("yyyy-MM-dd");
             _fDateStr = _minDate;
         }
+
+        _scheduleItemTypes = await ScheduleItemTypeSvc.GetForEventAsync(SeedService.Id.EventCcn2026);
+        _fTypeId = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
 
         _locations  = await LocationSvc.GetAllAsync();
         _activities = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
@@ -303,21 +312,21 @@
         _loading = false;
     }
 
-    private void StartEdit(ScheduleEvent ev)
+    private void StartEdit(ScheduleItem ev)
     {
-        _editingId      = ev.ScheduleEventId;
+        _editingId      = ev.ScheduleItemId;
         _fTitle         = ev.Title;
         _fDesc          = ev.Description;
         _fDateStr       = ev.CampDay.ToString("yyyy-MM-dd");
         _fStartStr      = ev.StartTime.ToString("HH:mm");
         _fEndStr        = ev.EndTime?.ToString("HH:mm") ?? "";
-        _fType          = ev.EventType;
+        _fTypeId        = ev.ScheduleItemTypeId;
         _fLocationId    = ev.LocationId;
         _fPresenterName = ev.PresenterName;
         _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
         {
-            var existing = ev.EventGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
+            var existing = ev.ItemGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
             return new AssignmentFormRow
             {
                 GroupId    = g.GroupId,
@@ -326,7 +335,7 @@
                 Note       = existing?.Note
             };
         }).ToList();
-        _assignmentsExpanded = ev.EventGroups.Any();
+        _assignmentsExpanded = ev.ItemGroups.Any();
         _error = "";
     }
 
@@ -338,7 +347,7 @@
         _fDateStr            = _minDate;
         _fStartStr           = "";
         _fEndStr             = "";
-        _fType               = ScheduleEventType.Activity;
+        _fTypeId             = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
         _fLocationId         = null;
         _fPresenterName      = null;
         _fPresenterBio       = null;
@@ -353,6 +362,7 @@
         if (string.IsNullOrWhiteSpace(_fTitle))    { _error = "Title is required."; return; }
         if (string.IsNullOrWhiteSpace(_fDateStr))  { _error = "Day is required."; return; }
         if (string.IsNullOrWhiteSpace(_fStartStr)) { _error = "Start time is required."; return; }
+        if (_fTypeId == Guid.Empty)                { _error = "Type is required."; return; }
         if (!DateOnly.TryParseExact(_fDateStr,  "yyyy-MM-dd", out var day))   { _error = "Invalid date."; return; }
         if (!TimeOnly.TryParseExact(_fStartStr, "HH:mm", out var start))      { _error = "Invalid start time."; return; }
         TimeOnly? end = string.IsNullOrEmpty(_fEndStr) ? null
@@ -363,13 +373,13 @@
             .Select(a => new GroupAssignmentDto(a.GroupId, a.ActivityId, a.LocationId, a.Note))
             .ToList();
 
-        var isPresentation = _fType == ScheduleEventType.Presentation;
-        var dto = new ScheduleEventDto(
+        var isPresentation = SelectedTypeSystemName == "Presentation";
+        var dto = new ScheduleItemDto(
             _editingId,
             SeedService.Id.EventCcn2026,
             day, start, end,
             _fTitle.Trim(), _fDesc,
-            _fLocationId, _fType,
+            _fLocationId, _fTypeId,
             !assignments.Any(),
             null, assignments,
             isPresentation ? _fPresenterName : null,
@@ -381,27 +391,24 @@
         await Reload();
     }
 
-    private async Task DeleteAsync(ScheduleEvent ev)
+    private async Task DeleteAsync(ScheduleItem ev)
     {
-        await ScheduleSvc.DeleteAsync(ev.ScheduleEventId);
+        await ScheduleSvc.DeleteAsync(ev.ScheduleItemId);
         Snackbar.Add($"{ev.Title} deleted.", Severity.Info);
         await Reload();
     }
 
-    private static string DisplayEventType(ScheduleEventType t) => t switch
-    {
-        ScheduleEventType.Travel => "Arrival/Departure",
-        _ => t.ToString()
-    };
+    private static string DisplayItemType(ScheduleItemType? t) =>
+        t?.SystemName == "Travel" ? "Arrival/Departure" : (t?.Name ?? "—");
 
-    private static string EventTypeBadgeColor(ScheduleEventType t) => t switch
+    private static string ItemTypeBadgeColor(string? systemName) => systemName switch
     {
-        ScheduleEventType.Meal         => "#E67E22",
-        ScheduleEventType.Travel       => "#2980B9",
-        ScheduleEventType.Free         => "#27AE60",
-        ScheduleEventType.Mandatory    => "#D12B2B",
-        ScheduleEventType.Presentation => "#8E44AD",
-        _                              => "#8E44AD"
+        "Meal"         => "#E67E22",
+        "Travel"       => "#2980B9",
+        "Free"         => "#27AE60",
+        "Mandatory"    => "#D12B2B",
+        "Presentation" => "#9B59B6",
+        _              => "#8E44AD"
     };
 
     private class AssignmentFormRow

--- a/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
+++ b/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
@@ -1,12 +1,26 @@
 @page "/admin/schedule-item-types"
 @attribute [Authorize(Roles = "Admin")]
+@using Microsoft.EntityFrameworkCore
 @inject ScheduleItemTypeService ScheduleItemTypeSvc
+@inject IDbContextFactory<AppDbContext> DbFactory
 @inject ISnackbar Snackbar
 
 <PageTitle>Schedule Types Admin — Camp Clot Not</PageTitle>
 
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">🗂️ Schedule Item Types</h2>
+
+    @* ── Event selector ── *@
+    <div style="margin-bottom:20px;max-width:340px">
+        <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Configure for Event</div>
+        <select @onchange="OnEventChanged"
+                style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none">
+            @foreach (var ev in _events)
+            {
+                <option value="@ev.EventId" selected="@(ev.EventId == _selectedEventId)">@ev.Name</option>
+            }
+        </select>
+    </div>
 
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
@@ -65,7 +79,7 @@
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">#</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">System Name</th>
-                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Enabled '26</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Enabled</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                             </tr>
                         </thead>
@@ -114,6 +128,9 @@
 </div>
 
 @code {
+    private List<Event> _events = new();
+    private Guid _selectedEventId;
+
     private List<ScheduleItemType> _types = new();
     private HashSet<Guid> _enabledIds = new();
     private bool _loading = true;
@@ -124,12 +141,27 @@
     private int _fSortOrder = 10;
     private string _error = "";
 
-    protected override async Task OnInitializedAsync() => await Reload();
+    protected override async Task OnInitializedAsync()
+    {
+        await using var db = await DbFactory.CreateDbContextAsync();
+        _events = await db.Events.OrderByDescending(e => e.EffDate).ToListAsync();
+        _selectedEventId = _events.FirstOrDefault(e => e.IsActive)?.EventId
+                        ?? _events.FirstOrDefault()?.EventId
+                        ?? SeedService.Id.EventCcn2026;
+        await Reload();
+    }
+
+    private async Task OnEventChanged(ChangeEventArgs e)
+    {
+        if (Guid.TryParse(e.Value?.ToString(), out var id))
+            _selectedEventId = id;
+        await Reload();
+    }
 
     private async Task Reload()
     {
         _types      = await ScheduleItemTypeSvc.GetAllAsync();
-        _enabledIds = (await ScheduleItemTypeSvc.GetEnabledIdsForEventAsync(SeedService.Id.EventCcn2026)).ToHashSet();
+        _enabledIds = (await ScheduleItemTypeSvc.GetEnabledIdsForEventAsync(_selectedEventId)).ToHashSet();
         _loading    = false;
     }
 
@@ -189,10 +221,10 @@
 
     private async Task ToggleEventTypeAsync(Guid typeId, bool enabled)
     {
-        await ScheduleItemTypeSvc.SetEventTypeEnabledAsync(SeedService.Id.EventCcn2026, typeId, enabled);
+        await ScheduleItemTypeSvc.SetEventTypeEnabledAsync(_selectedEventId, typeId, enabled);
         if (enabled) _enabledIds.Add(typeId); else _enabledIds.Remove(typeId);
     }
 
     private static bool IsBuiltIn(string systemName) =>
-        systemName is "Activity" or "Meal" or "Travel" or "Free" or "Mandatory" or "Presentation";
+        systemName is "Activity" or "Meal" or "Travel" or "Presentation";
 }

--- a/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
+++ b/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
@@ -1,0 +1,198 @@
+@page "/admin/schedule-item-types"
+@attribute [Authorize(Roles = "Admin")]
+@inject ScheduleItemTypeService ScheduleItemTypeSvc
+@inject ISnackbar Snackbar
+
+<PageTitle>Schedule Types Admin — Camp Clot Not</PageTitle>
+
+<div style="padding: 0 16px 100px">
+    <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">🗂️ Schedule Item Types</h2>
+
+    <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
+
+        @* ── Form panel ── *@
+        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
+            <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Type" : "Edit Type")</h3>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Name</div>
+                <input type="text" @bind="_fName" placeholder="e.g. Workshop"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Description (optional)</div>
+                <input type="text" @bind="_fDescription" placeholder="Brief description"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            <div style="margin-bottom:14px">
+                <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Sort Order</div>
+                <input type="number" @bind="_fSortOrder" min="1"
+                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(_error))
+            {
+                <div style="color:#D12B2B;font-size:12px;margin-bottom:10px">@_error</div>
+            }
+
+            <div style="display:flex;gap:8px">
+                <button class="ccn-btn" @onclick="SaveAsync">@(_editingId == Guid.Empty ? "Add Type" : "Save Changes")</button>
+                @if (_editingId != Guid.Empty)
+                {
+                    <button class="ccn-btn" style="background:transparent" @onclick="CancelEdit">Cancel</button>
+                }
+            </div>
+        </div>
+
+        @* ── Table ── *@
+        <div style="flex:1;min-width:300px">
+            @if (_loading)
+            {
+                <MudProgressCircular Indeterminate="true" />
+            }
+            else if (!_types.Any())
+            {
+                <p style="color:var(--text-light);font-family:'Fredoka One',cursive">No types yet. Add the first one →</p>
+            }
+            else
+            {
+                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;margin-bottom:24px">
+                    <table style="width:100%;border-collapse:collapse">
+                        <thead>
+                            <tr style="background:var(--black)">
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">#</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">System Name</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Enabled '26</th>
+                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var t in _types)
+                            {
+                                var enabled = _enabledIds.Contains(t.ScheduleItemTypeId);
+                                <tr style="border-bottom:2px solid #E8E0CC">
+                                    <td style="padding:8px 14px;font-size:13px;color:var(--text-light)">@t.SortOrder</td>
+                                    <td style="padding:8px 14px;font-size:13px;font-weight:700">
+                                        @t.Name
+                                        @if (!string.IsNullOrEmpty(t.Description))
+                                        {
+                                            <div style="font-size:11px;color:var(--text-light);font-weight:400">@t.Description</div>
+                                        }
+                                    </td>
+                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid);font-family:monospace">@t.SystemName</td>
+                                    <td style="padding:8px 14px">
+                                        <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:@(enabled ? "#27AE60" : "transparent");color:@(enabled ? "white" : "var(--text-dark)")"
+                                                @onclick="() => ToggleEventTypeAsync(t.ScheduleItemTypeId, !enabled)">
+                                            @(enabled ? "✓ On" : "Off")
+                                        </button>
+                                    </td>
+                                    <td style="padding:8px 10px">
+                                        <div style="display:flex;gap:4px">
+                                            <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(t)">Edit</button>
+                                            @if (string.IsNullOrEmpty(t.SystemName) || !IsBuiltIn(t.SystemName))
+                                            {
+                                                <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(t)">Del</button>
+                                            }
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+                <div style="font-size:12px;color:var(--text-light);font-family:'Nunito',sans-serif">
+                    <strong>System Name</strong> is a stable code identifier used for special UI logic (e.g. Presentation shows speaker fields, Travel shows as "Arrival/Departure"). Built-in types cannot be deleted.
+                </div>
+            }
+        </div>
+
+    </div>
+</div>
+
+@code {
+    private List<ScheduleItemType> _types = new();
+    private HashSet<Guid> _enabledIds = new();
+    private bool _loading = true;
+    private Guid _editingId;
+
+    private string _fName = "";
+    private string? _fDescription;
+    private int _fSortOrder = 10;
+    private string _error = "";
+
+    protected override async Task OnInitializedAsync() => await Reload();
+
+    private async Task Reload()
+    {
+        _types      = await ScheduleItemTypeSvc.GetAllAsync();
+        _enabledIds = (await ScheduleItemTypeSvc.GetEnabledIdsForEventAsync(SeedService.Id.EventCcn2026)).ToHashSet();
+        _loading    = false;
+    }
+
+    private void StartEdit(ScheduleItemType t)
+    {
+        _editingId    = t.ScheduleItemTypeId;
+        _fName        = t.Name;
+        _fDescription = t.Description;
+        _fSortOrder   = t.SortOrder;
+        _error        = "";
+    }
+
+    private void CancelEdit()
+    {
+        _editingId    = Guid.Empty;
+        _fName        = "";
+        _fDescription = null;
+        _fSortOrder   = 10;
+        _error        = "";
+    }
+
+    private async Task SaveAsync()
+    {
+        _error = "";
+        if (string.IsNullOrWhiteSpace(_fName)) { _error = "Name is required."; return; }
+
+        var existing = _editingId != Guid.Empty
+            ? _types.FirstOrDefault(t => t.ScheduleItemTypeId == _editingId)
+            : null;
+
+        var type = new ScheduleItemType
+        {
+            ScheduleItemTypeId = _editingId == Guid.Empty ? Guid.Empty : _editingId,
+            Name               = _fName.Trim(),
+            SystemName         = existing?.SystemName ?? _fName.Trim().Replace(" ", ""),
+            Description        = _fDescription,
+            SortOrder          = _fSortOrder,
+        };
+
+        await ScheduleItemTypeSvc.UpsertAsync(type);
+        Snackbar.Add(_editingId == Guid.Empty ? $"{_fName} added." : $"{_fName} updated.", Severity.Success);
+        CancelEdit();
+        await Reload();
+    }
+
+    private async Task DeleteAsync(ScheduleItemType t)
+    {
+        var ok = await ScheduleItemTypeSvc.DeleteAsync(t.ScheduleItemTypeId);
+        if (!ok)
+            Snackbar.Add($"Cannot delete \"{t.Name}\" — it is assigned to schedule items.", Severity.Warning);
+        else
+        {
+            Snackbar.Add($"{t.Name} deleted.", Severity.Info);
+            await Reload();
+        }
+    }
+
+    private async Task ToggleEventTypeAsync(Guid typeId, bool enabled)
+    {
+        await ScheduleItemTypeSvc.SetEventTypeEnabledAsync(SeedService.Id.EventCcn2026, typeId, enabled);
+        if (enabled) _enabledIds.Add(typeId); else _enabledIds.Remove(typeId);
+    }
+
+    private static bool IsBuiltIn(string systemName) =>
+        systemName is "Activity" or "Meal" or "Travel" or "Free" or "Mandatory" or "Presentation";
+}

--- a/CampClotNot/Pages/Admin/Users.razor
+++ b/CampClotNot/Pages/Admin/Users.razor
@@ -38,8 +38,14 @@
 
             <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Temporary Password</div>
-                <input type="password" @bind="_form.Password" placeholder="••••••••"
-                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                <div style="position:relative">
+                    <input type="@(_showCreatePw ? "text" : "password")" @bind="_form.Password" placeholder="••••••••"
+                           style="width:100%;padding:9px 40px 9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                    <button type="button" @onclick="() => _showCreatePw = !_showCreatePw"
+                            style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;font-size:16px;padding:0;line-height:1;color:var(--text-light)">
+                        @(_showCreatePw ? "🙈" : "👁")
+                    </button>
+                </div>
             </div>
 
             <div style="margin-bottom:14px">
@@ -85,21 +91,41 @@
             }
             else
             {
+                @* Search / filter toolbar *@
+                <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap">
+                    <input type="text" @bind="_search" @bind:event="oninput" placeholder="Search name or email…"
+                           style="flex:1;min-width:160px;padding:8px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:13px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                    <select @bind="_roleFilter"
+                            style="padding:8px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:13px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;cursor:pointer">
+                        <option value="">All roles</option>
+                        <option value="Admin">Admin</option>
+                        <option value="MedicalStaff">Medical Staff</option>
+                        <option value="Staff">Staff</option>
+                        <option value="Volunteer">Volunteer</option>
+                    </select>
+                </div>
+
                 <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <div style="overflow-x:auto">
                         <table style="width:100%;border-collapse:collapse;min-width:600px">
                             <thead>
                                 <tr style="background:var(--black)">
-                                    <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
+                                    <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left;cursor:pointer;user-select:none"
+                                        @onclick='() => SetSort("name")'>
+                                        Name @SortIndicator("name")
+                                    </th>
                                     <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Email</th>
-                                    <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Role</th>
+                                    <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left;cursor:pointer;user-select:none"
+                                        @onclick='() => SetSort("role")'>
+                                        Role @SortIndicator("role")
+                                    </th>
                                     <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Group</th>
                                     <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Active</th>
                                     <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var u in _users)
+                                @foreach (var u in FilteredUsers)
                                 {
                                     <tr style="border-bottom:2px solid #E8E0CC">
                                         <td style="padding:10px 14px;font-size:13px;font-weight:700">@u.FirstName @u.LastName</td>
@@ -118,6 +144,14 @@
                                                     <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:#E67E22;color:white" @onclick="() => DeactivateAsync(u)">Deactivate</button>
                                                 }
                                             </div>
+                                        </td>
+                                    </tr>
+                                }
+                                @if (!FilteredUsers.Any())
+                                {
+                                    <tr>
+                                        <td colspan="6" style="padding:16px 14px;font-size:13px;color:var(--text-light);font-style:italic">
+                                            No users match your search.
                                         </td>
                                     </tr>
                                 }
@@ -212,14 +246,26 @@
 
             <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">New Password</div>
-                <input type="password" @bind="_resetPassword" placeholder="••••••••"
-                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                <div style="position:relative">
+                    <input type="@(_showResetPw ? "text" : "password")" @bind="_resetPassword" placeholder="••••••••"
+                           style="width:100%;padding:9px 40px 9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                    <button type="button" @onclick="() => _showResetPw = !_showResetPw"
+                            style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;font-size:16px;padding:0;line-height:1;color:var(--text-light)">
+                        @(_showResetPw ? "🙈" : "👁")
+                    </button>
+                </div>
             </div>
 
             <div style="margin-bottom:14px">
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:5px">Confirm Password</div>
-                <input type="password" @bind="_resetConfirm" placeholder="••••••••"
-                       style="width:100%;padding:9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                <div style="position:relative">
+                    <input type="@(_showResetConfirm ? "text" : "password")" @bind="_resetConfirm" placeholder="••••••••"
+                           style="width:100%;padding:9px 40px 9px 12px;background:var(--bg-base);border:3px solid var(--black);border-radius:7px;font-size:14px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;box-sizing:border-box" />
+                    <button type="button" @onclick="() => _showResetConfirm = !_showResetConfirm"
+                            style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;font-size:16px;padding:0;line-height:1;color:var(--text-light)">
+                        @(_showResetConfirm ? "🙈" : "👁")
+                    </button>
+                </div>
             </div>
 
             @if (_resetError is not null)
@@ -251,6 +297,56 @@
     private string _resetPassword = "";
     private string _resetConfirm = "";
     private string? _resetError;
+
+    private bool _showCreatePw;
+    private bool _showResetPw;
+    private bool _showResetConfirm;
+
+    private string _search = "";
+    private string _roleFilter = "";
+    private string _sortColumn = "role";
+    private bool _sortAsc = true;
+
+    private static int RoleRank(string systemName) => systemName switch
+    {
+        "Admin"        => 0,
+        "MedicalStaff" => 1,
+        "Staff"        => 2,
+        _              => 3
+    };
+
+    private IEnumerable<User> FilteredUsers
+    {
+        get
+        {
+            var q = _users.AsEnumerable();
+            if (!string.IsNullOrWhiteSpace(_search))
+                q = q.Where(u =>
+                    u.FirstName.Contains(_search, StringComparison.OrdinalIgnoreCase) ||
+                    u.LastName.Contains(_search, StringComparison.OrdinalIgnoreCase) ||
+                    u.Email.Contains(_search, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(_roleFilter))
+                q = q.Where(u => u.UserRole.SystemName == _roleFilter);
+            return _sortColumn switch
+            {
+                "name" => _sortAsc
+                    ? q.OrderBy(u => u.LastName).ThenBy(u => u.FirstName)
+                    : q.OrderByDescending(u => u.LastName).ThenByDescending(u => u.FirstName),
+                _ => _sortAsc
+                    ? q.OrderBy(u => RoleRank(u.UserRole.SystemName)).ThenBy(u => u.LastName).ThenBy(u => u.FirstName)
+                    : q.OrderByDescending(u => RoleRank(u.UserRole.SystemName)).ThenBy(u => u.LastName).ThenBy(u => u.FirstName)
+            };
+        }
+    }
+
+    private void SetSort(string col)
+    {
+        if (_sortColumn == col) _sortAsc = !_sortAsc;
+        else { _sortColumn = col; _sortAsc = true; }
+    }
+
+    private string SortIndicator(string col) =>
+        _sortColumn == col ? (_sortAsc ? "▲" : "▼") : "";
 
     protected override async Task OnInitializedAsync()
     {
@@ -310,6 +406,8 @@
         _resetPassword = "";
         _resetConfirm = "";
         _resetError = null;
+        _showResetPw = false;
+        _showResetConfirm = false;
         _resetOpen = true;
     }
 
@@ -317,6 +415,8 @@
     {
         _resetOpen = false;
         _resetting = null;
+        _showResetPw = false;
+        _showResetConfirm = false;
     }
 
     private async Task SubmitResetAsync()

--- a/CampClotNot/Pages/Dashboard.razor
+++ b/CampClotNot/Pages/Dashboard.razor
@@ -188,7 +188,7 @@ else
 
 @code {
     private List<Sponsor>       _sponsors           = new();
-    private List<ScheduleEvent> _todayEvents        = new();
+    private List<ScheduleItem>  _todayEvents        = new();
     private Announcement?       _latestAnnouncement;
     private bool                _loading            = true;
 

--- a/CampClotNot/Pages/Dashboard.razor
+++ b/CampClotNot/Pages/Dashboard.razor
@@ -1,8 +1,10 @@
 @page "/dashboard"
 @attribute [Authorize]
+@using Microsoft.EntityFrameworkCore
 @inject SponsorService SponsorSvc
 @inject ScheduleService ScheduleSvc
 @inject AnnouncementService AnnouncementSvc
+@inject IDbContextFactory<AppDbContext> DbFactory
 
 <PageTitle>Home — Camp Clot Not</PageTitle>
 
@@ -98,7 +100,9 @@ else
         @* Today's Schedule *@
         <div class="ccn-panel" style="padding:18px;animation:slideUp .3s ease;border-top:5px solid #2980B9">
             <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
-                <div style="font-family:'Fredoka One',cursive;font-size:16px;color:var(--black)">📅 Today's Schedule</div>
+                <div style="font-family:'Fredoka One',cursive;font-size:16px;color:var(--black)">
+                    📅 @(_scheduleDay != DateOnly.FromDateTime(DateTime.Today) ? $"{_scheduleDay:MMM d} Schedule" : "Today's Schedule")
+                </div>
                 <a href="/hub/schedule" style="font-size:11px;font-family:'Fredoka One',cursive;
                                                color:#2980B9;text-decoration:none">Full →</a>
             </div>
@@ -191,13 +195,34 @@ else
     private List<ScheduleItem>  _todayEvents        = new();
     private Announcement?       _latestAnnouncement;
     private bool                _loading            = true;
+    private DateOnly            _scheduleDay;
+    private bool                _showingFirstDay;
 
     protected override async Task OnInitializedAsync()
     {
         _sponsors = await SponsorSvc.GetAllForEventAsync(SeedService.Id.EventCcn2026);
 
         var today = DateOnly.FromDateTime(DateTime.Today);
-        _todayEvents = await ScheduleSvc.GetForDayAsync(SeedService.Id.EventCcn2026, today);
+        using var db = DbFactory.CreateDbContext();
+        var campEvent = await db.Events.FindAsync(SeedService.Id.EventCcn2026);
+
+        if (campEvent is not null)
+        {
+            if (today < campEvent.EffDate)
+            {
+                _scheduleDay     = campEvent.EffDate;
+                _showingFirstDay = true;
+            }
+            else
+            {
+                _scheduleDay = today <= campEvent.ExpDate ? today : campEvent.ExpDate;
+            }
+        }
+        else
+        {
+            _scheduleDay = today;
+        }
+        _todayEvents = await ScheduleSvc.GetForDayAsync(SeedService.Id.EventCcn2026, _scheduleDay);
 
         var feed = await AnnouncementSvc.GetFeedAsync();
         _latestAnnouncement = feed.FirstOrDefault();

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -1,6 +1,7 @@
 @page "/hub/schedule"
 @attribute [Authorize(Roles = "Admin,Staff,Volunteer")]
 @inject ScheduleService ScheduleSvc
+@inject ScheduleItemTypeService ScheduleItemTypeSvc
 @inject LocationService LocationSvc
 @inject MiniGameService MiniGameSvc
 @inject IDbContextFactory<AppDbContext> DbFactory
@@ -108,7 +109,7 @@
                     @foreach (var ev in dayEvents)
                     {
                         var myAssignment = _userGroupId.HasValue
-                            ? ev.EventGroups.FirstOrDefault(eg => eg.GroupId == _userGroupId.Value)
+                            ? ev.ItemGroups.FirstOrDefault(eg => eg.GroupId == _userGroupId.Value)
                             : null;
 
                         <div style="padding:10px 16px;border-bottom:2px solid #E8E0CC;display:flex;gap:12px;align-items:flex-start">
@@ -142,11 +143,11 @@
                                     <div style="font-size:13px;color:var(--text-light)">@myAssignment.Note</div>
                                 }
 
-                                <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@EventTypeBadgeColor(ev.EventType);color:white;font-family:'Fredoka One',cursive">
-                                    @DisplayEventType(ev.EventType)
+                                <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@ItemTypeBadgeColor(ev.ScheduleItemType?.SystemName);color:white;font-family:'Fredoka One',cursive">
+                                    @DisplayItemType(ev.ScheduleItemType)
                                 </span>
 
-                                @if (ev.EventType == ScheduleEventType.Presentation && ev.PresenterName is not null)
+                                @if (ev.ScheduleItemType?.SystemName == "Presentation" && ev.PresenterName is not null)
                                 {
                                     <div style="font-size:13px;margin-top:4px;color:var(--text-mid)">🎤 @ev.PresenterName</div>
                                     @if (ev.PresenterBio is not null)
@@ -158,14 +159,14 @@
                                     }
                                 }
 
-                                @if (_isAdminOrStaff && ev.EventGroups.Any())
+                                @if (_isAdminOrStaff && ev.ItemGroups.Any())
                                 {
                                     <details style="margin-top:8px">
                                         <summary style="font-size:12px;color:var(--text-light);cursor:pointer;font-family:'Fredoka One',cursive">
-                                            Group assignments (@ev.EventGroups.Count)
+                                            Group assignments (@ev.ItemGroups.Count)
                                         </summary>
                                         <div style="margin-top:6px;border:2px solid #E8E0CC;border-radius:6px;overflow:hidden">
-                                            @foreach (var eg in ev.EventGroups.OrderBy(x => x.Group.Name))
+                                            @foreach (var eg in ev.ItemGroups.OrderBy(x => x.Group.Name))
                                             {
                                                 <div style="display:flex;gap:8px;align-items:center;padding:6px 10px;border-bottom:1px solid #E8E0CC;font-size:13px">
                                                     <span style="font-family:'Fredoka One',cursive;color:@eg.Group.Color;min-width:36px">@eg.Group.ShortName</span>
@@ -188,7 +189,7 @@
                             {
                                 <div style="display:flex;gap:4px;flex-shrink:0">
                                     <button class="ccn-btn" style="font-size:11px;padding:4px 8px" @onclick="() => OpenEditForm(ev)">Edit</button>
-                                    <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => DeleteEvent(ev.ScheduleEventId)">Del</button>
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => DeleteEvent(ev.ScheduleItemId)">Del</button>
                                 </div>
                             }
                         </div>
@@ -211,13 +212,13 @@
                            MaxDate="_campEvent is not null ? (DateTime?)_campEvent.ExpDate.ToDateTime(TimeOnly.MinValue) : null" />
             <MudTimePicker @bind-Time="_fStart"    Label="Start Time" Required="true" Class="mb-3" />
             <MudTimePicker @bind-Time="_fEnd"      Label="End Time (optional)" Class="mb-3" />
-            <MudSelect @bind-Value="_fType"        Label="Event Type" Class="mb-3">
-                @foreach (var t in Enum.GetValues<ScheduleEventType>())
+            <MudSelect Value="_fTypeId" ValueChanged="@((Guid v) => _fTypeId = v)" Label="Event Type" Class="mb-3">
+                @foreach (var t in _scheduleItemTypes)
                 {
-                    <MudSelectItem Value="@t">@DisplayEventType(t)</MudSelectItem>
+                    <MudSelectItem Value="@t.ScheduleItemTypeId">@DisplayItemType(t)</MudSelectItem>
                 }
             </MudSelect>
-            @if (_fType == ScheduleEventType.Presentation)
+            @if (SelectedTypeSystemName == "Presentation")
             {
                 <MudTextField @bind-Value="_fPresenterName" Label="Presenter Name" Class="mb-3" />
                 <MudTextField @bind-Value="_fPresenterBio"  Label="Presenter Bio (optional)" Lines="3" Class="mb-3" />
@@ -308,7 +309,8 @@
     private Guid? _userGroupId;
     private Event? _campEvent;
     private DateOnly? _selectedDay;
-    private Dictionary<DateOnly, List<ScheduleEvent>> _eventsByDay = new();
+    private Dictionary<DateOnly, List<ScheduleItem>> _eventsByDay = new();
+    private List<ScheduleItemType> _scheduleItemTypes = new();
     private List<Location> _locations = new();
     private List<Activity> _activities = new();
     private List<Group> _groups = new();
@@ -321,12 +323,15 @@
     private DateTime? _fDate;
     private TimeSpan? _fStart;
     private TimeSpan? _fEnd;
-    private ScheduleEventType _fType = ScheduleEventType.Activity;
+    private Guid _fTypeId;
     private Guid? _fLocationId;
     private string? _fPresenterName;
     private string? _fPresenterBio;
     private List<AssignmentFormRow> _fAssignments = new();
     private bool _assignmentsExpanded;
+
+    private string? SelectedTypeSystemName =>
+        _scheduleItemTypes.FirstOrDefault(t => t.ScheduleItemTypeId == _fTypeId)?.SystemName;
 
     protected override async Task OnInitializedAsync()
     {
@@ -347,11 +352,13 @@
         using var dbEvent = DbFactory.CreateDbContext();
         _campEvent = await dbEvent.Events.FindAsync(SeedService.Id.EventCcn2026);
 
-        // Default selected day: today if within camp dates, otherwise first camp day
         var today = DateOnly.FromDateTime(DateTime.Today);
         _selectedDay = (_campEvent is not null && today >= _campEvent.EffDate && today <= _campEvent.ExpDate)
             ? today
             : _campEvent?.EffDate;
+
+        _scheduleItemTypes = await ScheduleItemTypeSvc.GetForEventAsync(SeedService.Id.EventCcn2026);
+        _fTypeId = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
 
         _locations = await LocationSvc.GetAllAsync();
         _activities = await MiniGameSvc.GetActivitiesAsync(SeedService.Id.EventCcn2026);
@@ -393,7 +400,7 @@
         _fTitle         = ""; _fDesc = null;
         _fDate          = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
         _fStart         = new TimeSpan(9, 0, 0); _fEnd = null;
-        _fType          = ScheduleEventType.Activity;
+        _fTypeId        = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
         _fLocationId    = null;
         _fPresenterName = null; _fPresenterBio = null;
         _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
@@ -401,21 +408,21 @@
         _showForm            = true;
     }
 
-    private void OpenEditForm(ScheduleEvent ev)
+    private void OpenEditForm(ScheduleItem ev)
     {
-        _editingId      = ev.ScheduleEventId;
+        _editingId      = ev.ScheduleItemId;
         _fTitle         = ev.Title;
         _fDesc          = ev.Description;
         _fDate          = ev.CampDay.ToDateTime(TimeOnly.MinValue);
         _fStart         = ev.StartTime.ToTimeSpan();
         _fEnd           = ev.EndTime?.ToTimeSpan();
-        _fType          = ev.EventType;
+        _fTypeId        = ev.ScheduleItemTypeId;
         _fLocationId    = ev.LocationId;
         _fPresenterName = ev.PresenterName;
         _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
         {
-            var existing = ev.EventGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
+            var existing = ev.ItemGroups.FirstOrDefault(eg => eg.GroupId == g.GroupId);
             return new AssignmentFormRow
             {
                 GroupId    = g.GroupId,
@@ -424,7 +431,7 @@
                 Note       = existing?.Note
             };
         }).ToList();
-        _assignmentsExpanded = ev.EventGroups.Any();
+        _assignmentsExpanded = ev.ItemGroups.Any();
         _showForm = true;
     }
 
@@ -439,14 +446,14 @@
             .Select(a => new GroupAssignmentDto(a.GroupId, a.ActivityId, a.LocationId, a.Note))
             .ToList();
 
-        var isPresentation = _fType == ScheduleEventType.Presentation;
-        var dto = new ScheduleEventDto(
+        var isPresentation = SelectedTypeSystemName == "Presentation";
+        var dto = new ScheduleItemDto(
             _editingId,
             SeedService.Id.EventCcn2026,
             DateOnly.FromDateTime(_fDate.Value),
             TimeOnly.FromTimeSpan(_fStart.Value),
             _fEnd.HasValue ? TimeOnly.FromTimeSpan(_fEnd.Value) : null,
-            _fTitle, _fDesc, _fLocationId, _fType,
+            _fTitle, _fDesc, _fLocationId, _fTypeId,
             !assignments.Any(),
             null, assignments,
             isPresentation ? _fPresenterName : null,
@@ -454,7 +461,6 @@
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
 
-        // Switch to the saved day's tab after save
         _selectedDay = DateOnly.FromDateTime(_fDate.Value);
         _showForm = false;
         await LoadEvents();
@@ -466,20 +472,17 @@
         await LoadEvents();
     }
 
-    private static string DisplayEventType(ScheduleEventType t) => t switch
-    {
-        ScheduleEventType.Travel => "Arrival/Departure",
-        _ => t.ToString()
-    };
+    private static string DisplayItemType(ScheduleItemType? t) =>
+        t?.SystemName == "Travel" ? "Arrival/Departure" : (t?.Name ?? "—");
 
-    private static string EventTypeBadgeColor(ScheduleEventType t) => t switch
+    private static string ItemTypeBadgeColor(string? systemName) => systemName switch
     {
-        ScheduleEventType.Meal         => "#E67E22",
-        ScheduleEventType.Travel       => "#2980B9",
-        ScheduleEventType.Free         => "#27AE60",
-        ScheduleEventType.Mandatory    => "#D12B2B",
-        ScheduleEventType.Presentation => "#8E44AD",
-        _                              => "#8E44AD"
+        "Meal"         => "#E67E22",
+        "Travel"       => "#2980B9",
+        "Free"         => "#27AE60",
+        "Mandatory"    => "#D12B2B",
+        "Presentation" => "#9B59B6",
+        _              => "#8E44AD"
     };
 
     private class AssignmentFormRow

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -57,6 +57,18 @@
         text-transform: uppercase;
         margin-top: 1px;
     }
+    .sched-form-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 0 16px;
+    }
+    .sched-form-grid .full { grid-column: 1 / -1; }
+    @@media (max-width: 500px) {
+        .sched-form-grid { grid-template-columns: 1fr; }
+        .sched-form-grid .full { grid-column: 1; }
+    }
+    .sched-item-actions { display: flex; gap: 4px; flex-shrink: 0; }
+    @@media (max-width: 700px) { .sched-item-actions { display: none; } }
 </style>
 
 <div style="padding: 0 16px 100px">
@@ -112,41 +124,44 @@
                             ? ev.ItemGroups.FirstOrDefault(eg => eg.GroupId == _userGroupId.Value)
                             : null;
 
-                        <div style="padding:10px 16px;border-bottom:2px solid #E8E0CC;display:flex;gap:12px;align-items:flex-start">
-                            <div style="min-width:70px;font-family:'Fredoka One',cursive;font-size:13px;color:var(--text-light)">
-                                @ev.StartTime.ToString("h:mm tt")
-                                @if (ev.EndTime.HasValue)
-                                {
-                                    <br />@ev.EndTime.Value.ToString("h:mm tt")
-                                }
+                        var displayActivity = myAssignment?.Activity ?? ev.Activity;
+                        var displayLocation = myAssignment?.Location ?? ev.Location;
+                        var timeStr = ev.EndTime.HasValue
+                            ? $"{ev.StartTime:h:mm tt} – {ev.EndTime.Value:h:mm tt}"
+                            : ev.StartTime.ToString("h:mm tt");
+                        <div style="padding:10px 14px;border-bottom:3px solid #3a3a3a;display:flex;gap:10px;align-items:flex-start">
+                            <div style="min-width:80px;flex-shrink:0;font-family:'Fredoka One',cursive;font-size:12px;color:var(--text-mid);padding-top:2px">
+                                @timeStr
                             </div>
                             <div style="flex:1;min-width:0">
-                                @if (myAssignment?.Activity is not null)
+                                <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+                                    <span style="font-family:'Fredoka One',cursive;font-size:14px;color:var(--black)">
+                                        @(displayActivity?.Name ?? ev.Title)
+                                    </span>
+                                    <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@ItemTypeBadgeColor(ev.ScheduleItemType?.SystemName);color:white;font-family:'Fredoka One',cursive;flex-shrink:0">
+                                        @DisplayItemType(ev.ScheduleItemType)
+                                    </span>
+                                    @if (displayLocation is not null)
+                                    {
+                                        <span style="font-size:12px;font-weight:900;font-family:'Fredoka One',cursive;color:var(--black);background:#DDD5C0;padding:2px 8px;border-radius:4px;border:2px solid #6B5540;flex-shrink:0">
+                                            📍 @displayLocation.Name
+                                        </span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(ev.LocationOther))
+                                    {
+                                        <span style="font-size:12px;font-weight:900;font-family:'Fredoka One',cursive;color:var(--black);background:#DDD5C0;padding:2px 8px;border-radius:4px;border:2px solid #6B5540;flex-shrink:0">
+                                            📍 @ev.LocationOther
+                                        </span>
+                                    }
+                                    @if (displayLocation is null && string.IsNullOrEmpty(ev.LocationOther) && !string.IsNullOrEmpty(myAssignment?.Note))
+                                    {
+                                        <span style="font-size:12px;color:var(--text-mid);font-style:italic">@myAssignment.Note</span>
+                                    }
+                                </div>
+                                @if (displayActivity is not null)
                                 {
-                                    <div style="font-family:'Fredoka One',cursive;font-size:15px">@myAssignment.Activity.Name</div>
-                                    <div style="font-size:12px;color:var(--text-light);font-style:italic">@ev.Title</div>
+                                    <div style="font-size:11px;color:var(--text-light);font-style:italic;margin-top:2px">@ev.Title</div>
                                 }
-                                else
-                                {
-                                    <div style="font-family:'Fredoka One',cursive;font-size:15px">@ev.Title</div>
-                                }
-
-                                @{
-                                    var displayLocation = myAssignment?.Location ?? ev.Location;
-                                }
-                                @if (displayLocation is not null)
-                                {
-                                    <div style="font-size:13px;color:var(--text-light)">📍 @displayLocation.Name</div>
-                                }
-                                else if (!string.IsNullOrEmpty(myAssignment?.Note))
-                                {
-                                    <div style="font-size:13px;color:var(--text-light)">@myAssignment.Note</div>
-                                }
-
-                                <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@ItemTypeBadgeColor(ev.ScheduleItemType?.SystemName);color:white;font-family:'Fredoka One',cursive">
-                                    @DisplayItemType(ev.ScheduleItemType)
-                                </span>
-
                                 @if (ev.ScheduleItemType?.SystemName == "Presentation" && ev.PresenterName is not null)
                                 {
                                     <div style="font-size:13px;margin-top:4px;color:var(--text-mid)">🎤 @ev.PresenterName</div>
@@ -158,26 +173,25 @@
                                         </details>
                                     }
                                 }
-
                                 @if (_isAdminOrStaff && ev.ItemGroups.Any())
                                 {
-                                    <details style="margin-top:8px">
+                                    <details style="margin-top:6px">
                                         <summary style="font-size:12px;color:var(--text-light);cursor:pointer;font-family:'Fredoka One',cursive">
                                             Group assignments (@ev.ItemGroups.Count)
                                         </summary>
-                                        <div style="margin-top:6px;border:2px solid #E8E0CC;border-radius:6px;overflow:hidden">
+                                        <div style="margin-top:6px;border:2px solid #9E8C70;border-radius:6px;overflow:hidden">
                                             @foreach (var eg in ev.ItemGroups.OrderBy(x => x.Group.Name))
                                             {
-                                                <div style="display:flex;gap:8px;align-items:center;padding:6px 10px;border-bottom:1px solid #E8E0CC;font-size:13px">
+                                                <div style="display:flex;gap:8px;align-items:center;padding:6px 10px;border-bottom:1px solid #C0A882;font-size:13px">
                                                     <span style="font-family:'Fredoka One',cursive;color:@eg.Group.Color;min-width:36px">@eg.Group.ShortName</span>
                                                     <span style="flex:1">@(eg.Activity?.Name ?? "—")</span>
                                                     @if (eg.Location is not null)
                                                     {
-                                                        <span style="color:var(--text-light)">📍 @eg.Location.Name</span>
+                                                        <span style="font-weight:600;color:var(--black)">📍 @eg.Location.Name</span>
                                                     }
                                                     @if (!string.IsNullOrEmpty(eg.Note))
                                                     {
-                                                        <span style="color:var(--text-light);font-style:italic">@eg.Note</span>
+                                                        <span style="color:var(--text-mid);font-style:italic">@eg.Note</span>
                                                     }
                                                 </div>
                                             }
@@ -187,7 +201,7 @@
                             </div>
                             @if (_canEdit)
                             {
-                                <div style="display:flex;gap:4px;flex-shrink:0">
+                                <div class="sched-item-actions">
                                     <button class="ccn-btn" style="font-size:11px;padding:4px 8px" @onclick="() => OpenEditForm(ev)">Edit</button>
                                     <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => DeleteEvent(ev.ScheduleItemId)">Del</button>
                                 </div>
@@ -203,34 +217,56 @@
 @if (_showForm)
 {
     <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .2s ease" @onclick="CloseForm">
-        <div class="ccn-panel" style="padding:24px;width:100%;max-width:560px;max-height:90vh;overflow-y:auto;box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease" @onclick:stopPropagation>
+        <div class="ccn-panel" style="padding:24px;width:100%;max-width:680px;max-height:90vh;overflow-y:auto;box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease" @onclick:stopPropagation>
             <h3 style="font-family:'Fredoka One',cursive;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Event" : "Edit Event")</h3>
 
-            <MudTextField @bind-Value="_fTitle"    Label="Title" Required="true" Class="mb-3" />
-            <MudDatePicker @bind-Date="_fDate"     Label="Day" Required="true" Class="mb-3"
-                           MinDate="_campEvent is not null ? (DateTime?)_campEvent.EffDate.ToDateTime(TimeOnly.MinValue) : null"
-                           MaxDate="_campEvent is not null ? (DateTime?)_campEvent.ExpDate.ToDateTime(TimeOnly.MinValue) : null" />
-            <MudTimePicker @bind-Time="_fStart"    Label="Start Time" Required="true" Class="mb-3" />
-            <MudTimePicker @bind-Time="_fEnd"      Label="End Time (optional)" Class="mb-3" />
-            <MudSelect Value="_fTypeId" ValueChanged="@((Guid v) => _fTypeId = v)" Label="Event Type" Class="mb-3">
-                @foreach (var t in _scheduleItemTypes)
-                {
-                    <MudSelectItem Value="@t.ScheduleItemTypeId">@DisplayItemType(t)</MudSelectItem>
-                }
-            </MudSelect>
-            @if (SelectedTypeSystemName == "Presentation")
-            {
-                <MudTextField @bind-Value="_fPresenterName" Label="Presenter Name" Class="mb-3" />
-                <MudTextField @bind-Value="_fPresenterBio"  Label="Presenter Bio (optional)" Lines="3" Class="mb-3" />
-            }
-            <MudTextField @bind-Value="_fDesc"     Label="Description (optional)" Lines="2" Class="mb-3" />
+            <div class="sched-form-grid">
+                <div class="full">
+                    <MudTextField @bind-Value="_fTitle" Label="Title" Required="true" Class="mb-3" />
+                </div>
 
-            <MudSelect @bind-Value="_fLocationId" Label="Location (optional)" Class="mb-3" Clearable="true">
-                @foreach (var loc in _locations)
+                <MudDatePicker @bind-Date="_fDate" Label="Day" Required="true" Class="mb-3"
+                               MinDate="_campEvent is not null ? (DateTime?)_campEvent.EffDate.ToDateTime(TimeOnly.MinValue) : null"
+                               MaxDate="_campEvent is not null ? (DateTime?)_campEvent.ExpDate.ToDateTime(TimeOnly.MinValue) : null" />
+                <MudSelect Value="_fTypeId" ValueChanged="@((Guid v) => _fTypeId = v)" Label="Type" Class="mb-3">
+                    @foreach (var t in _scheduleItemTypes)
+                    {
+                        <MudSelectItem Value="@t.ScheduleItemTypeId">@DisplayItemType(t)</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <MudTextField @bind-Value="_fStartStr" Label="Start Time" Placeholder="9:30 AM" Required="true" Class="mb-3" />
+                <MudTextField @bind-Value="_fEndStr"   Label="End Time (optional)" Placeholder="10:30 AM" Class="mb-3" />
+
+                <MudSelect @bind-Value="_fActivityId" Label="Activity (optional)" Class="mb-3" Clearable="true">
+                    @foreach (var act in _activities)
+                    {
+                        <MudSelectItem Value="@((Guid?)act.ActivityId)">@act.Name</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudSelect @bind-Value="_fLocationId" Label="Location (optional)" Class="mb-3" Clearable="true">
+                    @foreach (var loc in _locations)
+                    {
+                        <MudSelectItem Value="@((Guid?)loc.LocationId)">@loc.Name</MudSelectItem>
+                    }
+                </MudSelect>
+
+                <div class="full">
+                    <MudTextField @bind-Value="_fLocationOther" Label="Additional location / other (optional)" Placeholder="e.g. Gym + Pool deck" Class="mb-3" />
+                </div>
+
+                <div class="full">
+                    <MudTextField @bind-Value="_fDesc" Label="Description (optional)" Lines="2" Class="mb-3" />
+                </div>
+
+                @if (SelectedTypeSystemName == "Presentation")
                 {
-                    <MudSelectItem Value="@((Guid?)loc.LocationId)">@loc.Name</MudSelectItem>
+                    <div class="full">
+                        <MudTextField @bind-Value="_fPresenterName" Label="Presenter Name" Class="mb-3" />
+                        <MudTextField @bind-Value="_fPresenterBio"  Label="Presenter Bio (optional)" Lines="3" Class="mb-3" />
+                    </div>
                 }
-            </MudSelect>
+            </div>
 
             @{
                 var assignedCount = _fAssignments.Count(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note));
@@ -321,10 +357,12 @@
     private string _fTitle = "";
     private string? _fDesc;
     private DateTime? _fDate;
-    private TimeSpan? _fStart;
-    private TimeSpan? _fEnd;
+    private string _fStartStr = "";
+    private string _fEndStr = "";
     private Guid _fTypeId;
     private Guid? _fLocationId;
+    private string? _fLocationOther;
+    private Guid? _fActivityId;
     private string? _fPresenterName;
     private string? _fPresenterBio;
     private List<AssignmentFormRow> _fAssignments = new();
@@ -353,9 +391,15 @@
         _campEvent = await dbEvent.Events.FindAsync(SeedService.Id.EventCcn2026);
 
         var today = DateOnly.FromDateTime(DateTime.Today);
-        _selectedDay = (_campEvent is not null && today >= _campEvent.EffDate && today <= _campEvent.ExpDate)
-            ? today
-            : _campEvent?.EffDate;
+        if (_campEvent is not null)
+        {
+            if (today < _campEvent.EffDate)
+                _selectedDay = _campEvent.EffDate;
+            else if (today > _campEvent.ExpDate)
+                _selectedDay = _campEvent.ExpDate;
+            else
+                _selectedDay = today;
+        }
 
         _scheduleItemTypes = await ScheduleItemTypeSvc.GetForEventAsync(SeedService.Id.EventCcn2026);
         _fTypeId = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
@@ -398,10 +442,12 @@
     {
         _editingId      = Guid.Empty;
         _fTitle         = ""; _fDesc = null;
-        _fDate          = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
-        _fStart         = new TimeSpan(9, 0, 0); _fEnd = null;
+        _fDate     = _selectedDay?.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
+        _fStartStr = ""; _fEndStr = "";
         _fTypeId        = _scheduleItemTypes.FirstOrDefault()?.ScheduleItemTypeId ?? Guid.Empty;
         _fLocationId    = null;
+        _fLocationOther = null;
+        _fActivityId    = null;
         _fPresenterName = null; _fPresenterBio = null;
         _fAssignments        = _groups.Select(g => new AssignmentFormRow { GroupId = g.GroupId }).ToList();
         _assignmentsExpanded = false;
@@ -413,11 +459,13 @@
         _editingId      = ev.ScheduleItemId;
         _fTitle         = ev.Title;
         _fDesc          = ev.Description;
-        _fDate          = ev.CampDay.ToDateTime(TimeOnly.MinValue);
-        _fStart         = ev.StartTime.ToTimeSpan();
-        _fEnd           = ev.EndTime?.ToTimeSpan();
+        _fDate     = ev.CampDay.ToDateTime(TimeOnly.MinValue);
+        _fStartStr = ev.StartTime.ToString("h:mm tt");
+        _fEndStr   = ev.EndTime?.ToString("h:mm tt") ?? "";
         _fTypeId        = ev.ScheduleItemTypeId;
         _fLocationId    = ev.LocationId;
+        _fLocationOther = ev.LocationOther;
+        _fActivityId    = ev.ActivityId;
         _fPresenterName = ev.PresenterName;
         _fPresenterBio  = ev.PresenterBio;
         _fAssignments = _groups.Select(g =>
@@ -439,7 +487,8 @@
 
     private async Task SaveEvent()
     {
-        if (string.IsNullOrWhiteSpace(_fTitle) || _fDate is null || _fStart is null) return;
+        if (string.IsNullOrWhiteSpace(_fTitle) || _fDate is null || string.IsNullOrWhiteSpace(_fStartStr)) return;
+        if (!DateTime.TryParse(_fStartStr, out var startDt)) return;
 
         var assignments = _fAssignments
             .Where(a => a.ActivityId.HasValue || a.LocationId.HasValue || !string.IsNullOrEmpty(a.Note))
@@ -447,17 +496,20 @@
             .ToList();
 
         var isPresentation = SelectedTypeSystemName == "Presentation";
+        TimeOnly? end = !string.IsNullOrWhiteSpace(_fEndStr) && DateTime.TryParse(_fEndStr, out var endDt)
+            ? TimeOnly.FromDateTime(endDt) : null;
         var dto = new ScheduleItemDto(
             _editingId,
             SeedService.Id.EventCcn2026,
             DateOnly.FromDateTime(_fDate.Value),
-            TimeOnly.FromTimeSpan(_fStart.Value),
-            _fEnd.HasValue ? TimeOnly.FromTimeSpan(_fEnd.Value) : null,
-            _fTitle, _fDesc, _fLocationId, _fTypeId,
+            TimeOnly.FromDateTime(startDt),
+            end,
+            _fTitle, _fDesc, _fLocationId, _fActivityId, _fTypeId,
             !assignments.Any(),
             null, assignments,
             isPresentation ? _fPresenterName : null,
-            isPresentation ? _fPresenterBio  : null
+            isPresentation ? _fPresenterBio  : null,
+            string.IsNullOrWhiteSpace(_fLocationOther) ? null : _fLocationOther.Trim()
         );
         await ScheduleSvc.UpsertAsync(dto, _userId);
 
@@ -472,8 +524,7 @@
         await LoadEvents();
     }
 
-    private static string DisplayItemType(ScheduleItemType? t) =>
-        t?.SystemName == "Travel" ? "Arrival/Departure" : (t?.Name ?? "—");
+    private static string DisplayItemType(ScheduleItemType? t) => t?.Name ?? "—";
 
     private static string ItemTypeBadgeColor(string? systemName) => systemName switch
     {

--- a/CampClotNot/Pages/Hub/Sponsors.razor
+++ b/CampClotNot/Pages/Hub/Sponsors.razor
@@ -40,7 +40,7 @@
                     }
                     @if (!string.IsNullOrEmpty(s.Phone))
                     {
-                        <a href="tel:@s.Phone" style="font-size:.85rem;font-weight:700;color:var(--color-primary);text-decoration:none;text-align:center;display:block">@s.Phone</a>
+                        <a href="@TelHref(s.Phone)" style="font-size:.85rem;font-weight:700;color:var(--color-primary);text-decoration:none;text-align:center;display:block">@s.Phone</a>
                     }
                 </div>
             }
@@ -82,4 +82,11 @@
 
     private static string LogoSrc(Sponsor s) =>
         s.LogoData is not null ? $"/sponsors/logo/{s.SponsorId}" : (s.LogoUrl ?? "");
+
+    private static string TelHref(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return "tel:";
+        var digits = System.Text.RegularExpressions.Regex.Replace(phone, @"[^\d]", "");
+        return $"tel:+1{digits}";
+    }
 }

--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -71,7 +71,9 @@
                 <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center">
                     @if (m.PhotoData is not null)
                     {
-                        <img src="/staff-photo/@m.StaffMemberId" style="width:64px;height:64px;object-fit:cover;border-radius:8px;border:2px solid var(--black);margin-bottom:8px" alt="@m.DisplayName" />
+                        <img src="/staff-photo/@m.StaffMemberId"
+                             style="width:64px;height:64px;object-fit:cover;object-position:@(m.PhotoObjectPosition ?? "50% 50%");border-radius:8px;border:2px solid var(--black);margin-bottom:8px"
+                             alt="@m.DisplayName" />
                     }
                     else
                     {
@@ -81,11 +83,11 @@
                     <div style="font-size:12px;color:var(--text-light);margin-bottom:8px">@m.RoleTitle</div>
                     @if (!string.IsNullOrEmpty(m.Phone))
                     {
-                        <a href="tel:@m.Phone" style="display:block;font-size:13px;color:var(--color-primary);text-decoration:none;margin-bottom:4px">@m.Phone</a>
+                        <a href="@TelHref(m.Phone)" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none;margin-bottom:4px">@m.Phone</a>
                     }
                     @if (!string.IsNullOrEmpty(m.Email))
                     {
-                        <a href="mailto:@m.Email" style="display:block;font-size:13px;color:var(--color-primary);text-decoration:none">@m.Email</a>
+                        <a href="mailto:@m.Email" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none">@m.Email</a>
                     }
                     @if (m.LinkedUserId.HasValue)
                     {
@@ -120,13 +122,30 @@
                 {
                     <div style="color:#D12B2B;font-size:12px;margin-top:4px">@_photoUploadError</div>
                 }
-                @if (_fPhotoData is not null)
+                @if (PhotoPreviewSrc is not null)
                 {
-                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">✅ File ready to upload</div>
-                }
-                else if (_currentHasPhoto)
-                {
-                    <div style="font-size:11px;color:var(--text-mid);margin-top:4px">Current: uploaded photo (leave blank to keep)</div>
+                    <div style="margin-top:10px">
+                        <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:6px">Position Preview</div>
+                        <div style="display:flex;gap:14px;align-items:flex-start;flex-wrap:wrap">
+                            <img src="@PhotoPreviewSrc"
+                                 style="width:96px;height:96px;object-fit:cover;object-position:@_fPhotoX% @_fPhotoY%;border-radius:8px;border:3px solid var(--black);flex-shrink:0"
+                                 alt="Preview" />
+                            <div style="flex:1;min-width:140px">
+                                <div style="margin-bottom:10px">
+                                    <div style="font-size:11px;font-weight:700;color:var(--text-mid);margin-bottom:3px">Horizontal — @_fPhotoX%</div>
+                                    <input type="range" min="0" max="100" value="@_fPhotoX"
+                                           @oninput="e => _fPhotoX = int.TryParse(e.Value?.ToString(), out var v) ? v : 50"
+                                           style="width:100%;accent-color:var(--black)" />
+                                </div>
+                                <div>
+                                    <div style="font-size:11px;font-weight:700;color:var(--text-mid);margin-bottom:3px">Vertical — @_fPhotoY%</div>
+                                    <input type="range" min="0" max="100" value="@_fPhotoY"
+                                           @oninput="e => _fPhotoY = int.TryParse(e.Value?.ToString(), out var v) ? v : 50"
+                                           style="width:100%;accent-color:var(--black)" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 }
             </div>
             <MudTextField @bind-Value="_form.Phone"       Label="Phone (optional)" Class="mb-2" />
@@ -152,6 +171,14 @@
     private string? _fPhotoContentType;
     private bool _currentHasPhoto;
     private string _photoUploadError = "";
+    private int _fPhotoX = 50;
+    private int _fPhotoY = 50;
+
+    private string? PhotoPreviewSrc => _fPhotoData is not null
+        ? $"data:{_fPhotoContentType};base64,{Convert.ToBase64String(_fPhotoData)}"
+        : _currentHasPhoto && _form.StaffMemberId != Guid.Empty
+            ? $"/staff-photo/{_form.StaffMemberId}"
+            : null;
 
     protected override async Task OnInitializedAsync()
     {
@@ -175,6 +202,7 @@
     {
         _form = new() { CampEventId = SeedService.Id.EventCcn2026, AvatarEmoji = "👤", IsVisible = true };
         _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = false; _photoUploadError = "";
+        _fPhotoX = 50; _fPhotoY = 50;
         _showForm   = true;
         _showImport = false;
     }
@@ -189,6 +217,7 @@
             IsVisible = m.IsVisible, SortOrder = m.SortOrder, LinkedUserId = m.LinkedUserId
         };
         _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = m.PhotoData is not null; _photoUploadError = "";
+        ParsePosition(m.PhotoObjectPosition);
         _showForm   = true;
         _showImport = false;
     }
@@ -197,12 +226,14 @@
     {
         _showForm = false;
         _fPhotoData = null; _fPhotoContentType = null; _currentHasPhoto = false; _photoUploadError = "";
+        _fPhotoX = 50; _fPhotoY = 50;
     }
 
     private async Task Save()
     {
-        _form.PhotoData        = _fPhotoData;
-        _form.PhotoContentType = _fPhotoContentType;
+        _form.PhotoData           = _fPhotoData;
+        _form.PhotoContentType    = _fPhotoContentType;
+        _form.PhotoObjectPosition = PhotoPreviewSrc is not null ? $"{_fPhotoX}% {_fPhotoY}%" : null;
         await StaffSvc.UpsertAsync(_form);
         Close();
         await Reload();
@@ -220,8 +251,24 @@
         using var stream = file.OpenReadStream(maxAllowedSize: 2 * 1024 * 1024);
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);
-        _fPhotoData = ms.ToArray();
+        _fPhotoData        = ms.ToArray();
         _fPhotoContentType = file.ContentType;
+        _fPhotoX = 50; _fPhotoY = 50;
+    }
+
+    private static string TelHref(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return "tel:";
+        var digits = System.Text.RegularExpressions.Regex.Replace(phone, @"[^\d]", "");
+        return $"tel:+1{digits}";
+    }
+
+    private void ParsePosition(string? pos)
+    {
+        if (string.IsNullOrWhiteSpace(pos)) { _fPhotoX = 50; _fPhotoY = 50; return; }
+        var parts = pos.Split(' ');
+        _fPhotoX = parts.Length > 0 && int.TryParse(parts[0].TrimEnd('%'), out var x) ? x : 50;
+        _fPhotoY = parts.Length > 1 && int.TryParse(parts[1].TrimEnd('%'), out var y) ? y : 50;
     }
 
     private async Task Delete(Guid id)

--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -65,6 +65,7 @@ try
     builder.Services.AddScoped<StaffDirectoryService>();
     builder.Services.AddScoped<AnnouncementService>();
     builder.Services.AddScoped<ScheduleService>();
+    builder.Services.AddScoped<ScheduleItemTypeService>();
     builder.Services.AddScoped<IncidentReportService>();
     builder.Services.AddScoped<SponsorService>();
     builder.Services.AddScoped<AuthService>();

--- a/CampClotNot/Services/ScheduleItemTypeService.cs
+++ b/CampClotNot/Services/ScheduleItemTypeService.cs
@@ -1,0 +1,86 @@
+using CampClotNot.Data;
+using CampClotNot.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CampClotNot.Services;
+
+public class ScheduleItemTypeService(IDbContextFactory<AppDbContext> factory)
+{
+    public async Task<List<ScheduleItemType>> GetAllAsync()
+    {
+        using var db = factory.CreateDbContext();
+        return await db.ScheduleItemTypes
+            .OrderBy(t => t.SortOrder).ThenBy(t => t.Name)
+            .ToListAsync();
+    }
+
+    public async Task<List<ScheduleItemType>> GetForEventAsync(Guid eventId)
+    {
+        using var db = factory.CreateDbContext();
+        return await db.EventScheduleItemTypes
+            .Where(e => e.EventId == eventId)
+            .Include(e => e.ScheduleItemType)
+            .OrderBy(e => e.ScheduleItemType.SortOrder)
+            .Select(e => e.ScheduleItemType)
+            .ToListAsync();
+    }
+
+    public async Task<List<Guid>> GetEnabledIdsForEventAsync(Guid eventId)
+    {
+        using var db = factory.CreateDbContext();
+        return await db.EventScheduleItemTypes
+            .Where(e => e.EventId == eventId)
+            .Select(e => e.ScheduleItemTypeId)
+            .ToListAsync();
+    }
+
+    public async Task UpsertAsync(ScheduleItemType type)
+    {
+        using var db = factory.CreateDbContext();
+        var existing = await db.ScheduleItemTypes.FindAsync(type.ScheduleItemTypeId);
+        if (existing is null)
+        {
+            if (type.ScheduleItemTypeId == Guid.Empty) type.ScheduleItemTypeId = Guid.NewGuid();
+            db.ScheduleItemTypes.Add(type);
+        }
+        else
+        {
+            existing.Name        = type.Name;
+            existing.Description = type.Description;
+            existing.SortOrder   = type.SortOrder;
+        }
+        await db.SaveChangesAsync();
+    }
+
+    public async Task<bool> DeleteAsync(Guid typeId)
+    {
+        using var db = factory.CreateDbContext();
+        var inUse = await db.ScheduleItems.AnyAsync(s => s.ScheduleItemTypeId == typeId);
+        if (inUse) return false;
+        var type = await db.ScheduleItemTypes.FindAsync(typeId);
+        if (type is null) return true;
+        db.ScheduleItemTypes.Remove(type);
+        await db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task SetEventTypeEnabledAsync(Guid eventId, Guid typeId, bool enabled)
+    {
+        using var db = factory.CreateDbContext();
+        var existing = await db.EventScheduleItemTypes
+            .FindAsync(eventId, typeId);
+        if (enabled && existing is null)
+        {
+            db.EventScheduleItemTypes.Add(new EventScheduleItemType
+            {
+                EventId            = eventId,
+                ScheduleItemTypeId = typeId
+            });
+        }
+        else if (!enabled && existing is not null)
+        {
+            db.EventScheduleItemTypes.Remove(existing);
+        }
+        await db.SaveChangesAsync();
+    }
+}

--- a/CampClotNot/Services/ScheduleService.cs
+++ b/CampClotNot/Services/ScheduleService.cs
@@ -15,12 +15,14 @@ public record ScheduleItemDto(
     string Title,
     string? Description,
     Guid? LocationId,
+    Guid? ActivityId,
     Guid ScheduleItemTypeId,
     bool AppliesToAllGroups,
     int? MaxCapacity,
     List<GroupAssignmentDto> Assignments,
     string? PresenterName = null,
-    string? PresenterBio = null
+    string? PresenterBio = null,
+    string? LocationOther = null
 );
 
 public class ScheduleService(IDbContextFactory<AppDbContext> factory)
@@ -32,6 +34,7 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
             .Where(e => e.CampEventId == campEventId)
             .Include(e => e.ScheduleItemType)
             .Include(e => e.Location)
+            .Include(e => e.Activity)
             .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Group)
             .Include(e => e.ItemGroups)
@@ -49,6 +52,7 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
             .Where(e => e.CampEventId == campEventId && e.CampDay == day)
             .Include(e => e.ScheduleItemType)
             .Include(e => e.Location)
+            .Include(e => e.Activity)
             .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Group)
             .Include(e => e.ItemGroups)
@@ -78,6 +82,8 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
                 Title              = dto.Title,
                 Description        = dto.Description,
                 LocationId         = dto.LocationId,
+                LocationOther      = dto.LocationOther,
+                ActivityId         = dto.ActivityId,
                 ScheduleItemTypeId = dto.ScheduleItemTypeId,
                 AppliesToAllGroups = dto.AppliesToAllGroups,
                 MaxCapacity        = dto.MaxCapacity,
@@ -107,6 +113,8 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
             existing.Title              = dto.Title;
             existing.Description        = dto.Description;
             existing.LocationId         = dto.LocationId;
+            existing.LocationOther      = dto.LocationOther;
+            existing.ActivityId         = dto.ActivityId;
             existing.ScheduleItemTypeId = dto.ScheduleItemTypeId;
             existing.AppliesToAllGroups = dto.AppliesToAllGroups;
             existing.MaxCapacity        = dto.MaxCapacity;

--- a/CampClotNot/Services/ScheduleService.cs
+++ b/CampClotNot/Services/ScheduleService.cs
@@ -6,8 +6,8 @@ namespace CampClotNot.Services;
 
 public record GroupAssignmentDto(Guid GroupId, Guid? ActivityId, Guid? LocationId, string? Note);
 
-public record ScheduleEventDto(
-    Guid ScheduleEventId,
+public record ScheduleItemDto(
+    Guid ScheduleItemId,
     Guid CampEventId,
     DateOnly CampDay,
     TimeOnly StartTime,
@@ -15,7 +15,7 @@ public record ScheduleEventDto(
     string Title,
     string? Description,
     Guid? LocationId,
-    ScheduleEventType EventType,
+    Guid ScheduleItemTypeId,
     bool AppliesToAllGroups,
     int? MaxCapacity,
     List<GroupAssignmentDto> Assignments,
@@ -25,50 +25,52 @@ public record ScheduleEventDto(
 
 public class ScheduleService(IDbContextFactory<AppDbContext> factory)
 {
-    public async Task<List<ScheduleEvent>> GetByEventAsync(Guid campEventId)
+    public async Task<List<ScheduleItem>> GetByEventAsync(Guid campEventId)
     {
         using var db = factory.CreateDbContext();
-        return await db.ScheduleEvents
+        return await db.ScheduleItems
             .Where(e => e.CampEventId == campEventId)
+            .Include(e => e.ScheduleItemType)
             .Include(e => e.Location)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Group)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Activity)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Location)
             .OrderBy(e => e.CampDay).ThenBy(e => e.StartTime)
             .ToListAsync();
     }
 
-    public async Task<List<ScheduleEvent>> GetForDayAsync(Guid campEventId, DateOnly day)
+    public async Task<List<ScheduleItem>> GetForDayAsync(Guid campEventId, DateOnly day)
     {
         using var db = factory.CreateDbContext();
-        return await db.ScheduleEvents
+        return await db.ScheduleItems
             .Where(e => e.CampEventId == campEventId && e.CampDay == day)
+            .Include(e => e.ScheduleItemType)
             .Include(e => e.Location)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Group)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Activity)
-            .Include(e => e.EventGroups)
+            .Include(e => e.ItemGroups)
                 .ThenInclude(eg => eg.Location)
             .OrderBy(e => e.StartTime)
             .ToListAsync();
     }
 
-    public async Task<ScheduleEvent> UpsertAsync(ScheduleEventDto dto, Guid userId)
+    public async Task<ScheduleItem> UpsertAsync(ScheduleItemDto dto, Guid userId)
     {
         using var db = factory.CreateDbContext();
-        var existing = await db.ScheduleEvents
-            .Include(e => e.EventGroups)
-            .FirstOrDefaultAsync(e => e.ScheduleEventId == dto.ScheduleEventId);
+        var existing = await db.ScheduleItems
+            .Include(e => e.ItemGroups)
+            .FirstOrDefaultAsync(e => e.ScheduleItemId == dto.ScheduleItemId);
 
         if (existing is null)
         {
-            var ev = new ScheduleEvent
+            var ev = new ScheduleItem
             {
-                ScheduleEventId    = dto.ScheduleEventId == Guid.Empty ? Guid.NewGuid() : dto.ScheduleEventId,
+                ScheduleItemId     = dto.ScheduleItemId == Guid.Empty ? Guid.NewGuid() : dto.ScheduleItemId,
                 CampEventId        = dto.CampEventId,
                 CampDay            = dto.CampDay,
                 StartTime          = dto.StartTime,
@@ -76,24 +78,24 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
                 Title              = dto.Title,
                 Description        = dto.Description,
                 LocationId         = dto.LocationId,
-                EventType          = dto.EventType,
+                ScheduleItemTypeId = dto.ScheduleItemTypeId,
                 AppliesToAllGroups = dto.AppliesToAllGroups,
                 MaxCapacity        = dto.MaxCapacity,
                 PresenterName      = dto.PresenterName,
                 PresenterBio       = dto.PresenterBio,
                 CreatedBy          = userId,
                 UpdatedAt          = DateTime.UtcNow,
-                EventGroups        = dto.Assignments
-                    .Select(a => new ScheduleEventGroup
+                ItemGroups         = dto.Assignments
+                    .Select(a => new ScheduleItemGroup
                     {
-                        ScheduleEventId = Guid.Empty, // set by EF after insert
-                        GroupId         = a.GroupId,
-                        ActivityId      = a.ActivityId,
-                        LocationId      = a.LocationId,
-                        Note            = a.Note
+                        ScheduleItemId = Guid.Empty, // set by EF after insert
+                        GroupId        = a.GroupId,
+                        ActivityId     = a.ActivityId,
+                        LocationId     = a.LocationId,
+                        Note           = a.Note
                     }).ToList()
             };
-            db.ScheduleEvents.Add(ev);
+            db.ScheduleItems.Add(ev);
             await db.SaveChangesAsync();
             return ev;
         }
@@ -105,22 +107,22 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
             existing.Title              = dto.Title;
             existing.Description        = dto.Description;
             existing.LocationId         = dto.LocationId;
-            existing.EventType          = dto.EventType;
+            existing.ScheduleItemTypeId = dto.ScheduleItemTypeId;
             existing.AppliesToAllGroups = dto.AppliesToAllGroups;
             existing.MaxCapacity        = dto.MaxCapacity;
             existing.PresenterName      = dto.PresenterName;
             existing.PresenterBio       = dto.PresenterBio;
             existing.UpdatedAt          = DateTime.UtcNow;
 
-            db.ScheduleEventGroups.RemoveRange(existing.EventGroups);
-            existing.EventGroups = dto.Assignments
-                .Select(a => new ScheduleEventGroup
+            db.ScheduleItemGroups.RemoveRange(existing.ItemGroups);
+            existing.ItemGroups = dto.Assignments
+                .Select(a => new ScheduleItemGroup
                 {
-                    ScheduleEventId = existing.ScheduleEventId,
-                    GroupId         = a.GroupId,
-                    ActivityId      = a.ActivityId,
-                    LocationId      = a.LocationId,
-                    Note            = a.Note
+                    ScheduleItemId = existing.ScheduleItemId,
+                    GroupId        = a.GroupId,
+                    ActivityId     = a.ActivityId,
+                    LocationId     = a.LocationId,
+                    Note           = a.Note
                 }).ToList();
 
             await db.SaveChangesAsync();
@@ -128,15 +130,15 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory)
         }
     }
 
-    public async Task DeleteAsync(Guid scheduleEventId)
+    public async Task DeleteAsync(Guid scheduleItemId)
     {
         using var db = factory.CreateDbContext();
-        var ev = await db.ScheduleEvents
-            .Include(e => e.EventGroups)
-            .FirstOrDefaultAsync(e => e.ScheduleEventId == scheduleEventId);
+        var ev = await db.ScheduleItems
+            .Include(e => e.ItemGroups)
+            .FirstOrDefaultAsync(e => e.ScheduleItemId == scheduleItemId);
         if (ev is null) return;
-        db.ScheduleEventGroups.RemoveRange(ev.EventGroups);
-        db.ScheduleEvents.Remove(ev);
+        db.ScheduleItemGroups.RemoveRange(ev.ItemGroups);
+        db.ScheduleItems.Remove(ev);
         await db.SaveChangesAsync();
     }
 }

--- a/CampClotNot/Services/SeedService.cs
+++ b/CampClotNot/Services/SeedService.cs
@@ -114,6 +114,15 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
         public static readonly Guid InfoPageRules   = new("0000000e-000e-000e-000e-000000000001");
         public static readonly Guid InfoPageFaq     = new("0000000e-000e-000e-000e-000000000002");
         public static readonly Guid InfoPageMedical = new("0000000e-000e-000e-000e-000000000003");
+
+        // ScheduleItemTypes — stable IDs used for data migration (int enum → Guid FK)
+        // Order matches original ScheduleEventType enum: Activity=0, Meal=1, Travel=2, Free=3, Mandatory=4, Presentation=5
+        public static readonly Guid SitActivity     = new("0000000f-000f-000f-000f-000000000001");
+        public static readonly Guid SitMeal         = new("0000000f-000f-000f-000f-000000000002");
+        public static readonly Guid SitTravel       = new("0000000f-000f-000f-000f-000000000003");
+        public static readonly Guid SitFree         = new("0000000f-000f-000f-000f-000000000004");
+        public static readonly Guid SitMandatory    = new("0000000f-000f-000f-000f-000000000005");
+        public static readonly Guid SitPresentation = new("0000000f-000f-000f-000f-000000000006");
     }
 
     public async Task SeedAsync()
@@ -138,6 +147,8 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
         await SeedBoardSpacesAsync(db);
         await SeedGroupBoardPositionsAsync(db);
         await SeedInfoPagesAsync(db);
+        await SeedScheduleItemTypesAsync(db);
+        await SeedEventScheduleItemTypesAsync(db);
     }
 
     private async Task SeedUserRolesAsync(AppDbContext db)
@@ -577,5 +588,58 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
         }
         await db.SaveChangesAsync();
         logger.LogInformation("Seeded/verified CCN 2026 info pages.");
+    }
+
+    private async Task SeedScheduleItemTypesAsync(AppDbContext db)
+    {
+        var defs = new[]
+        {
+            new { Id = Id.SitActivity,     Name = "Activity",     SystemName = "Activity",     Description = (string?)"Scheduled camp activity",         SortOrder = 1 },
+            new { Id = Id.SitMeal,         Name = "Meal",         SystemName = "Meal",         Description = (string?)"Breakfast, lunch, or dinner",     SortOrder = 2 },
+            new { Id = Id.SitTravel,       Name = "Travel",       SystemName = "Travel",       Description = (string?)"Arrival or departure",            SortOrder = 3 },
+            new { Id = Id.SitFree,         Name = "Free Time",    SystemName = "Free",         Description = (string?)"Unstructured free time",          SortOrder = 4 },
+            new { Id = Id.SitMandatory,    Name = "Mandatory",    SystemName = "Mandatory",    Description = (string?)"All-group required session",      SortOrder = 5 },
+            new { Id = Id.SitPresentation, Name = "Presentation", SystemName = "Presentation", Description = (string?)"Speaker or educational session",  SortOrder = 6 },
+        };
+
+        foreach (var def in defs)
+        {
+            if (!await db.ScheduleItemTypes.AnyAsync(t => t.ScheduleItemTypeId == def.Id))
+            {
+                db.ScheduleItemTypes.Add(new Data.Entities.ScheduleItemType
+                {
+                    ScheduleItemTypeId = def.Id,
+                    Name               = def.Name,
+                    SystemName         = def.SystemName,
+                    Description        = def.Description,
+                    SortOrder          = def.SortOrder,
+                });
+            }
+        }
+        await db.SaveChangesAsync();
+        logger.LogInformation("Seeded ScheduleItemTypes.");
+    }
+
+    private async Task SeedEventScheduleItemTypesAsync(AppDbContext db)
+    {
+        var typeIds = new[]
+        {
+            Id.SitActivity, Id.SitMeal, Id.SitTravel,
+            Id.SitFree, Id.SitMandatory, Id.SitPresentation,
+        };
+
+        foreach (var typeId in typeIds)
+        {
+            if (!await db.EventScheduleItemTypes.AnyAsync(e => e.EventId == Id.EventCcn2026 && e.ScheduleItemTypeId == typeId))
+            {
+                db.EventScheduleItemTypes.Add(new Data.Entities.EventScheduleItemType
+                {
+                    EventId            = Id.EventCcn2026,
+                    ScheduleItemTypeId = typeId,
+                });
+            }
+        }
+        await db.SaveChangesAsync();
+        logger.LogInformation("Seeded EventScheduleItemTypes for CCN 2026.");
     }
 }

--- a/CampClotNot/Services/SeedService.cs
+++ b/CampClotNot/Services/SeedService.cs
@@ -123,6 +123,8 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
         public static readonly Guid SitFree         = new("0000000f-000f-000f-000f-000000000004");
         public static readonly Guid SitMandatory    = new("0000000f-000f-000f-000f-000000000005");
         public static readonly Guid SitPresentation = new("0000000f-000f-000f-000f-000000000006");
+        public static readonly Guid SitMeeting      = new("0000000f-000f-000f-000f-000000000007");
+        public static readonly Guid SitTask         = new("0000000f-000f-000f-000f-000000000008");
     }
 
     public async Task SeedAsync()
@@ -594,12 +596,12 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
     {
         var defs = new[]
         {
-            new { Id = Id.SitActivity,     Name = "Activity",     SystemName = "Activity",     Description = (string?)"Scheduled camp activity",         SortOrder = 1 },
-            new { Id = Id.SitMeal,         Name = "Meal",         SystemName = "Meal",         Description = (string?)"Breakfast, lunch, or dinner",     SortOrder = 2 },
-            new { Id = Id.SitTravel,       Name = "Travel",       SystemName = "Travel",       Description = (string?)"Arrival or departure",            SortOrder = 3 },
-            new { Id = Id.SitFree,         Name = "Free Time",    SystemName = "Free",         Description = (string?)"Unstructured free time",          SortOrder = 4 },
-            new { Id = Id.SitMandatory,    Name = "Mandatory",    SystemName = "Mandatory",    Description = (string?)"All-group required session",      SortOrder = 5 },
-            new { Id = Id.SitPresentation, Name = "Presentation", SystemName = "Presentation", Description = (string?)"Speaker or educational session",  SortOrder = 6 },
+            new { Id = Id.SitActivity,     Name = "Activity",     SystemName = "Activity",     Description = (string?)"Scheduled camp activity",        SortOrder = 1 },
+            new { Id = Id.SitMeal,         Name = "Meal",         SystemName = "Meal",         Description = (string?)"Breakfast, lunch, or dinner",    SortOrder = 2 },
+            new { Id = Id.SitTravel,       Name = "Travel",       SystemName = "Travel",       Description = (string?)"Arrival or departure",           SortOrder = 3 },
+            new { Id = Id.SitPresentation, Name = "Presentation", SystemName = "Presentation", Description = (string?)"Speaker or educational session", SortOrder = 4 },
+            new { Id = Id.SitMeeting,      Name = "Meeting",      SystemName = "Meeting",      Description = (string?)"Staff or group meeting",         SortOrder = 5 },
+            new { Id = Id.SitTask,         Name = "Task",         SystemName = "Task",         Description = (string?)"Action item or to-do",           SortOrder = 6 },
         };
 
         foreach (var def in defs)
@@ -625,7 +627,7 @@ public class SeedService(IDbContextFactory<AppDbContext> factory, IConfiguration
         var typeIds = new[]
         {
             Id.SitActivity, Id.SitMeal, Id.SitTravel,
-            Id.SitFree, Id.SitMandatory, Id.SitPresentation,
+            Id.SitPresentation, Id.SitMeeting, Id.SitTask,
         };
 
         foreach (var typeId in typeIds)

--- a/CampClotNot/Services/StaffDirectoryService.cs
+++ b/CampClotNot/Services/StaffDirectoryService.cs
@@ -92,6 +92,7 @@ public class StaffDirectoryService(IDbContextFactory<AppDbContext> factory)
                 existing.PhotoData        = member.PhotoData;
                 existing.PhotoContentType = member.PhotoContentType;
             }
+            existing.PhotoObjectPosition = member.PhotoObjectPosition;
         }
         await db.SaveChangesAsync();
     }

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -276,13 +276,14 @@
                         @if (_adminDropdownOpen)
                         {
                             <div class="nav-admin-panel">
-                                <a href="/admin/games"      @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
-                                <a href="/admin/activities" @onclick="() => _adminDropdownOpen = false">🎲 Activities</a>
-                                <a href="/admin/schedule"   @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
-                                <a href="/admin/groups"    @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
-                                <a href="/admin/users"     @onclick="() => _adminDropdownOpen = false">🔑 Users</a>
-                                <a href="/admin/locations" @onclick="() => _adminDropdownOpen = false">📍 Locations</a>
-                                <a href="/admin/sponsors"  @onclick="() => _adminDropdownOpen = false">🏆 Sponsors</a>
+                                <a href="/admin/games"               @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
+                                <a href="/admin/activities"          @onclick="() => _adminDropdownOpen = false">🎲 Activities</a>
+                                <a href="/admin/schedule"            @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
+                                <a href="/admin/schedule-item-types" @onclick="() => _adminDropdownOpen = false">🗂️ Schedule Types</a>
+                                <a href="/admin/groups"              @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
+                                <a href="/admin/users"               @onclick="() => _adminDropdownOpen = false">🔑 Users</a>
+                                <a href="/admin/locations"           @onclick="() => _adminDropdownOpen = false">📍 Locations</a>
+                                <a href="/admin/sponsors"            @onclick="() => _adminDropdownOpen = false">🏆 Sponsors</a>
                             </div>
                         }
                     </div>
@@ -351,14 +352,15 @@
     <div style="position:fixed;inset:0;z-index:51;background:rgba(26,26,26,.4)"
          @onclick="() => _adminSheetOpen = false"></div>
     <div class="nav-admin-sheet">
-        <a href="/transactions"    @onclick="() => _adminSheetOpen = false">📋 Transactions</a>
-        <a href="/admin/games"      @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
-        <a href="/admin/activities" @onclick="() => _adminSheetOpen = false">🎲 Activities</a>
-        <a href="/admin/schedule"   @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
-        <a href="/admin/groups"    @onclick="() => _adminSheetOpen = false">👥 Groups</a>
-        <a href="/admin/users"     @onclick="() => _adminSheetOpen = false">🔑 Users</a>
-        <a href="/admin/locations" @onclick="() => _adminSheetOpen = false">📍 Locations</a>
-        <a href="/admin/sponsors"  @onclick="() => _adminSheetOpen = false">🏆 Sponsors</a>
+        <a href="/transactions"              @onclick="() => _adminSheetOpen = false">📋 Transactions</a>
+        <a href="/admin/games"               @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
+        <a href="/admin/activities"          @onclick="() => _adminSheetOpen = false">🎲 Activities</a>
+        <a href="/admin/schedule"            @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
+        <a href="/admin/schedule-item-types" @onclick="() => _adminSheetOpen = false">🗂️ Schedule Types</a>
+        <a href="/admin/groups"              @onclick="() => _adminSheetOpen = false">👥 Groups</a>
+        <a href="/admin/users"               @onclick="() => _adminSheetOpen = false">🔑 Users</a>
+        <a href="/admin/locations"           @onclick="() => _adminSheetOpen = false">📍 Locations</a>
+        <a href="/admin/sponsors"            @onclick="() => _adminSheetOpen = false">🏆 Sponsors</a>
         <button onclick="window.location='/logout'">🚪 Sign Out</button>
     </div>
 }

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -105,6 +105,28 @@
     .nav-admin-panel button:last-child { border-bottom: none; }
     .nav-admin-panel a:hover,
     .nav-admin-panel button:hover { background: #F5EED8; }
+    .nav-admin-section {
+        padding: 5px 16px 4px;
+        font-size: 9px;
+        font-weight: 900;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        color: var(--text-light);
+        background: #EDE6D6;
+        border-bottom: 1px solid #DDD5C0;
+        cursor: default;
+    }
+    .nav-admin-sheet-section {
+        padding: 7px 20px 5px;
+        font-size: 10px;
+        font-weight: 900;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        color: var(--text-light);
+        background: #EDE6D6;
+        border-bottom: 1px solid #DDD5C0;
+        cursor: default;
+    }
 
     /* ── Bottom bar ── */
     .nav-bottom-bar {
@@ -276,12 +298,16 @@
                         @if (_adminDropdownOpen)
                         {
                             <div class="nav-admin-panel">
+                                <div class="nav-admin-section">Game</div>
                                 <a href="/admin/games"               @onclick="() => _adminDropdownOpen = false">🎮 Game Admin</a>
                                 <a href="/admin/activities"          @onclick="() => _adminDropdownOpen = false">🎲 Activities</a>
+                                <div class="nav-admin-section">Schedule</div>
                                 <a href="/admin/schedule"            @onclick="() => _adminDropdownOpen = false">📅 Schedule</a>
-                                <a href="/admin/schedule-item-types" @onclick="() => _adminDropdownOpen = false">🗂️ Schedule Types</a>
-                                <a href="/admin/groups"              @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
+                                <a href="/admin/schedule-item-types" @onclick="() => _adminDropdownOpen = false">🗂️ Types</a>
+                                <div class="nav-admin-section">People</div>
                                 <a href="/admin/users"               @onclick="() => _adminDropdownOpen = false">🔑 Users</a>
+                                <a href="/admin/groups"              @onclick="() => _adminDropdownOpen = false">👥 Groups</a>
+                                <div class="nav-admin-section">Venue & Content</div>
                                 <a href="/admin/locations"           @onclick="() => _adminDropdownOpen = false">📍 Locations</a>
                                 <a href="/admin/sponsors"            @onclick="() => _adminDropdownOpen = false">🏆 Sponsors</a>
                             </div>
@@ -353,12 +379,16 @@
          @onclick="() => _adminSheetOpen = false"></div>
     <div class="nav-admin-sheet">
         <a href="/transactions"              @onclick="() => _adminSheetOpen = false">📋 Transactions</a>
+        <div class="nav-admin-sheet-section">Game</div>
         <a href="/admin/games"               @onclick="() => _adminSheetOpen = false">🎮 Game Admin</a>
         <a href="/admin/activities"          @onclick="() => _adminSheetOpen = false">🎲 Activities</a>
+        <div class="nav-admin-sheet-section">Schedule</div>
         <a href="/admin/schedule"            @onclick="() => _adminSheetOpen = false">📅 Schedule</a>
-        <a href="/admin/schedule-item-types" @onclick="() => _adminSheetOpen = false">🗂️ Schedule Types</a>
-        <a href="/admin/groups"              @onclick="() => _adminSheetOpen = false">👥 Groups</a>
+        <a href="/admin/schedule-item-types" @onclick="() => _adminSheetOpen = false">🗂️ Types</a>
+        <div class="nav-admin-sheet-section">People</div>
         <a href="/admin/users"               @onclick="() => _adminSheetOpen = false">🔑 Users</a>
+        <a href="/admin/groups"              @onclick="() => _adminSheetOpen = false">👥 Groups</a>
+        <div class="nav-admin-sheet-section">Venue & Content</div>
         <a href="/admin/locations"           @onclick="() => _adminSheetOpen = false">📍 Locations</a>
         <a href="/admin/sponsors"            @onclick="() => _adminSheetOpen = false">🏆 Sponsors</a>
         <button onclick="window.location='/logout'">🚪 Sign Out</button>


### PR DESCRIPTION
## Summary

- **Table-driven ScheduleItemType**: replaced `ScheduleEventType` enum with `ScheduleItemType` entity + `EventScheduleItemType` join table; new `/admin/schedule-item-types` page with per-event enable/disable and event selector dropdown; added Meeting + Task types, removed Free + Mandatory from seed
- **Schedule UX**: 12-hr plain-text time inputs; two-column edit dialog (desktop); mobile hides edit/delete, single-line layout, dark dividers, bold location chip; nullable `ActivityId` FK; `LocationOther` freetext field; hub/schedule default tab follows today → first day → last day logic
- **Staff**: photo focal-point sliders stored as `object-position`; `tel:` links use E.164 for Android dialer; darker link color
- **Admin/Locations**: capacity hidden from UI; image preview in form + thumbnail in table with fullscreen lightbox on click
- **Admin/Users**: search + role filter + clickable sort headers (role-rank default); password visibility toggles
- **Dashboard**: fixed async DbContext disposal bug; three-case date logic (before/during/after event)
- **AppNav**: section headers in Admin dropdown — Game / Schedule / People / Venue & Content

## Migrations

Three new EF migrations (all applied to dev DB):
- `AddScheduleItemActivity` — nullable `ActivityId` FK on `ScheduleItems`
- `AddStaffPhotoObjectPosition` — `PhotoObjectPosition` on `StaffMembers`
- `AddScheduleItemLocationOther` — nullable `LocationOther` on `ScheduleItems`

## Test plan

- [ ] `/admin/schedule-item-types` — event dropdown switches config; enable/disable toggles persist; add/rename/delete custom types
- [ ] `/admin/schedule` — 12-hr time inputs parse correctly; ActivityId and LocationOther fields save and display
- [ ] `/hub/schedule` — two-column dialog on desktop collapses to one column on mobile; edit/delete hidden on mobile; location chip bold and visible; default tab = today (or first/last day outside event range)
- [ ] `/hub/staff` — upload photo, drag sliders, save; verify `object-position` on card; tel: links open dialer on Android
- [ ] `/admin/locations` — image thumbnail in table; click for lightbox; form shows current image preview
- [ ] `/admin/users` — search filters live; role dropdown filters; Name/Role headers sort; password toggle works on all three fields
- [ ] Dashboard — card shows correct day label before/during/after event dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)