### PR TITLE
fix: staff photo render size 64px → 96px (desktop blurriness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,18 @@ A Blazor Server (.NET 8) web app for Camp Clot Not (CCN), a camp for kids with b
 
 ---
 
-## Current State (as of 2026-06-04)
+## Current State (as of 2026-06-05)
 
-**Active branch:** `feature/124-v057-info-overhaul-ux-polish` — v0.5.7 in progress (final v0.5.x)
-**On dev (pending main PR):** v0.5.6 — table-driven schedule item types + UX polish
-**Released to main:** v0.5.5 — photos, sponsor enhancements, schedule improvements, dashboard
-**Next:** v0.5.7 (current branch) → then v1.0.0-rc.1 (see versioning below)
+**Active branch:** `dev` — v0.5.7 merged; RC phase begins next
+**On dev (pending main PR):** v0.5.7 — info overhaul, UX polish, PDF uploads, schedule table, bug fixes
+**Released to main:** v0.5.6 — table-driven schedule item types + UX polish *(pending PR #127)*
+**Next:** v1.0.0-rc.1 — first release candidate (see RC versioning below)
+
+**RC Versioning Convention (2026-06-05 onward):**
+- Format: `v1.0.0-rc.N` — increment N for every fix/tweak before camp goes live
+- Branch naming: `feature/N-v100rc1-description`, `feature/N-v100rc2-description`, etc. (open issue first)
+- **True v1.0.0 go-live date: June 19, 2026** (one day before camp June 20)
+- After go-live, any camp-week hotfixes are `v1.0.1`, `v1.0.2`, etc.
 
 **v0.1.0 — Done:**
 - Blazor Server project: entities, repositories, services, SignalR hub, MudBlazor pages

--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -74,7 +74,7 @@
                     @if (m.PhotoData is not null)
                     {
                         <img src="/staff-photo/@m.StaffMemberId"
-                             style="width:64px;height:64px;object-fit:cover;object-position:@(m.PhotoObjectPosition ?? "50% 50%");border-radius:8px;border:2px solid var(--black);margin-bottom:8px"
+                             style="width:96px;height:96px;object-fit:cover;object-position:@(m.PhotoObjectPosition ?? "50% 50%");border-radius:8px;border:2px solid var(--black);margin-bottom:8px"
                              alt="@m.DisplayName" />
                     }
                     else


### PR DESCRIPTION
## Summary

- Increases staff directory photo render size from `64px` to `96px` to fix blurriness on 1× DPR desktop displays
- Root cause: 400px stored image → 64px CSS = 6.25× downscale; browser bicubic interpolation blurs fine detail at that ratio
- Mobile looked fine (2–3× DPR = 128–192 physical px rendered); desktop at 100% zoom only got 64 physical px
- 96px cuts the downscale to ~4× and matches sharpness previously only visible at ~250% browser zoom
- Also updates CLAUDE.md with v1.0.0-rc versioning convention and June 19 go-live date

## Test plan

- [ ] Open `/hub/staff` on desktop at 100% zoom — photos visibly sharper than before
- [ ] Confirm card layout is not broken (cards are `minmax(160px,1fr)`, 96px photo fits cleanly)
- [ ] Check on mobile — should remain sharp as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)