### PR TITLE
fix: staff directory card alignment — flex column, buttons pinned to bottom

### DIFF
--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -70,7 +70,7 @@
         <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px">
             @foreach (var m in _members)
             {
-                <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center">
+                <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center;display:flex;flex-direction:column">
                     @if (m.PhotoData is not null)
                     {
                         <img src="/staff-photo/@m.StaffMemberId"
@@ -97,7 +97,7 @@
                     }
                     @if (_isAdmin)
                     {
-                        <div style="display:flex;gap:4px;margin-top:10px;justify-content:center">
+                        <div style="display:flex;gap:4px;margin-top:auto;padding-top:10px;justify-content:center">
                             <button class="ccn-btn" style="font-size:11px;padding:4px 8px" @onclick="() => OpenEdit(m)">Edit</button>
                             <button class="ccn-btn" style="font-size:11px;padding:4px 8px;background:#D12B2B" @onclick="() => Delete(m.StaffMemberId)">Del</button>
                         </div>

--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -79,7 +79,7 @@
                     }
                     else
                     {
-                        <div style="font-size:36px;margin-bottom:8px">@m.AvatarEmoji</div>
+                        <div style="width:100%;aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;font-size:48px;border-radius:8px;border:2px solid var(--black);margin-bottom:8px;background:#F5F0E4">@m.AvatarEmoji</div>
                     }
                     <div style="font-family:'Fredoka One',cursive;font-size:15px">@m.DisplayName</div>
                     <div style="font-size:12px;color:var(--text-light);margin-bottom:8px">@m.RoleTitle</div>


### PR DESCRIPTION
## Summary

- Card is now `display:flex; flex-direction:column` so photo/emoji, name, role, and contact info always stack from the top
- Edit/Del buttons use `margin-top:auto` to pin to the card bottom regardless of how much contact info is above them
- All cards in a row now have name, role, contact, and action buttons at consistent vertical positions
- Rolls up the previous two commits: emoji placeholder uniform height fix + this alignment fix

## Test plan

- [ ] Open `/hub/staff` as Admin — Edit/Del buttons should be at the same height across all cards in each row
- [ ] Cards with no phone/email should have the same button position as cards with full contact info
- [ ] Layout should look clean on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)