### PR TITLE
feat(v1.0.0-rc.1): graceful reconnect UX + mobile layout improvements

### DIFF
--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -12,6 +12,13 @@
 
 <PageTitle>Schedule Admin — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-sched-desc  { display: none; }
+        .admin-sched-loc-img { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">📅 Schedule Events</h2>
 
@@ -203,7 +210,8 @@
             else
             {
                 <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
-                    <table style="width:100%;border-collapse:collapse">
+                    <div style="overflow-x:auto">
+                    <table style="width:100%;border-collapse:collapse;min-width:520px">
                         <colgroup>
                             <col style="width:9%" />
                             <col style="width:13%" />
@@ -238,11 +246,11 @@
                                         @ev.Title
                                         @if (!string.IsNullOrEmpty(ev.Description))
                                         {
-                                            <div style="font-size:11px;color:var(--text-light)">@ev.Description</div>
+                                            <div class="admin-sched-desc" style="font-size:11px;color:var(--text-light)">@ev.Description</div>
                                         }
                                         @if (ev.ItemGroups.Any())
                                         {
-                                            <div style="font-size:11px;color:var(--text-light)">@ev.ItemGroups.Count group assign.</div>
+                                            <div class="admin-sched-desc" style="font-size:11px;color:var(--text-light)">@ev.ItemGroups.Count group assign.</div>
                                         }
                                     </td>
                                     <td style="padding:8px 14px">
@@ -257,6 +265,7 @@
                                                 @if (ev.Location.ImageData is not null)
                                                 {
                                                     <img src="/location-image/@ev.Location.LocationId"
+                                                         class="admin-sched-loc-img"
                                                          style="width:42px;height:30px;object-fit:cover;border-radius:3px;border:2px solid var(--black);cursor:zoom-in;flex-shrink:0"
                                                          alt="@ev.Location.Name"
                                                          @onclick='() => _lightboxSrc = $"/location-image/{ev.Location.LocationId}"' />
@@ -283,6 +292,7 @@
                             }
                         </tbody>
                     </table>
+                    </div>
                 </div>
             }
         </div>

--- a/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
+++ b/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
@@ -7,6 +7,12 @@
 
 <PageTitle>Schedule Types Admin — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .sit-col-sysname { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">🗂️ Schedule Item Types</h2>
 
@@ -73,12 +79,13 @@
             else
             {
                 <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;margin-bottom:24px">
-                    <table style="width:100%;border-collapse:collapse">
+                    <div style="overflow-x:auto">
+                    <table style="width:100%;border-collapse:collapse;min-width:360px">
                         <thead>
                             <tr style="background:var(--black)">
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">#</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Name</th>
-                                <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">System Name</th>
+                                <th class="sit-col-sysname" style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">System Name</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left">Enabled</th>
                                 <th style="padding:10px 14px;color:white;font-family:'Fredoka One',cursive;font-size:12px;text-align:left"></th>
                             </tr>
@@ -96,7 +103,7 @@
                                             <div style="font-size:11px;color:var(--text-light);font-weight:400">@t.Description</div>
                                         }
                                     </td>
-                                    <td style="padding:8px 14px;font-size:12px;color:var(--text-mid);font-family:monospace">@t.SystemName</td>
+                                    <td class="sit-col-sysname" style="padding:8px 14px;font-size:12px;color:var(--text-mid);font-family:monospace">@t.SystemName</td>
                                     <td style="padding:8px 14px">
                                         <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:@(enabled ? "#27AE60" : "transparent");color:@(enabled ? "white" : "var(--text-dark)")"
                                                 @onclick="() => ToggleEventTypeAsync(t.ScheduleItemTypeId, !enabled)">
@@ -116,6 +123,7 @@
                             }
                         </tbody>
                     </table>
+                    </div>
                 </div>
 
                 <div style="font-size:12px;color:var(--text-light);font-family:'Nunito',sans-serif">

--- a/CampClotNot/Pages/Dashboard.razor
+++ b/CampClotNot/Pages/Dashboard.razor
@@ -70,24 +70,24 @@ else
                 <span>🏆 Our Sponsors</span>
                 <a href="/hub/sponsors" style="font-size:11px;color:var(--color-primary);text-decoration:none">View all →</a>
             </div>
-            <div style="display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:flex-start">
+            <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(90px,1fr));gap:8px">
                 @foreach (var s in _sponsors)
                 {
+                    var cellStyle = "background:white;border:2px solid #D8D0BC;border-radius:8px;padding:6px;display:flex;align-items:center;justify-content:center;height:52px";
                     @if (!string.IsNullOrWhiteSpace(s.Website))
                     {
-                        <a href="@s.Website" target="_blank" rel="noopener noreferrer" style="text-decoration:none">
+                        <a href="@s.Website" target="_blank" rel="noopener noreferrer" style="text-decoration:none;@cellStyle;transition:opacity .15s"
+                           onmouseover="this.style.opacity='.75'" onmouseout="this.style.opacity='1'">
                             <img src="@SponsorLogoSrc(s)" alt="@s.Name"
-                                 style="height:52px;width:auto;max-width:130px;object-fit:contain;
-                                        background:white;border:2px solid #D8D0BC;border-radius:8px;padding:5px 8px;
-                                        transition:opacity .15s"
-                                 onmouseover="this.style.opacity='.75'" onmouseout="this.style.opacity='1'" />
+                                 style="width:100%;height:40px;object-fit:contain" />
                         </a>
                     }
                     else
                     {
-                        <img src="@SponsorLogoSrc(s)" alt="@s.Name"
-                             style="height:52px;width:auto;max-width:130px;object-fit:contain;
-                                    background:white;border:2px solid #D8D0BC;border-radius:8px;padding:5px 8px" />
+                        <div style="@cellStyle">
+                            <img src="@SponsorLogoSrc(s)" alt="@s.Name"
+                                 style="width:100%;height:40px;object-fit:contain" />
+                        </div>
                     }
                 }
             </div>

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -69,6 +69,9 @@
     }
     .sched-item-wrap { border-bottom: 3px solid #3a3a3a; }
     .sched-item-wrap:last-child { border-bottom: none; }
+    @@media (max-width: 699px) {
+        .sched-loc-img { display: none; }
+    }
     .sched-row {
         display: grid;
         grid-template-columns: 80px 1fr;
@@ -196,7 +199,7 @@
                                         {
                                             @if (displayLocation.ImageData is not null)
                                             {
-                                                <img src="/location-image/@displayLocation.LocationId" style="width:56px;height:40px;object-fit:cover;border-radius:3px;border:2px solid var(--black);cursor:zoom-in;flex-shrink:0;vertical-align:middle" alt="@displayLocation.Name" @onclick='() => _lightboxSrc = $"/location-image/{displayLocation.LocationId}"' />
+                                                <img src="/location-image/@displayLocation.LocationId" class="sched-loc-img" style="width:56px;height:40px;object-fit:cover;border-radius:3px;border:2px solid var(--black);cursor:zoom-in;flex-shrink:0;vertical-align:middle" alt="@displayLocation.Name" @onclick='() => _lightboxSrc = $"/location-image/{displayLocation.LocationId}"' />
                                             }
                                             <span style="font-size:12px;font-weight:900;font-family:'Fredoka One',cursive;color:var(--black);background:#DDD5C0;padding:2px 8px;border-radius:4px;border:2px solid #6B5540;flex-shrink:0">📍 @displayLocation.Name</span>
                                         }

--- a/CampClotNot/Pages/Hub/Sponsors.razor
+++ b/CampClotNot/Pages/Hub/Sponsors.razor
@@ -19,20 +19,22 @@
     }
     else
     {
-        <div style="display:flex;flex-wrap:wrap;gap:16px">
+        <div class="sponsors-grid">
             @foreach (var s in _sponsors)
             {
                 <div class="sponsor-tile">
-                    @if (!string.IsNullOrWhiteSpace(s.Website))
-                    {
-                        <a href="@s.Website" target="_blank" rel="noopener noreferrer" class="sponsor-logo-link">
-                            <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
-                        </a>
-                    }
-                    else
-                    {
-                        <img src="@LogoSrc(s)" alt="@s.Name" style="height:80px;width:auto;max-width:160px;object-fit:contain" />
-                    }
+                    <div class="sponsor-logo-box">
+                        @if (!string.IsNullOrWhiteSpace(s.Website))
+                        {
+                            <a href="@s.Website" target="_blank" rel="noopener noreferrer" class="sponsor-logo-link">
+                                <img src="@LogoSrc(s)" alt="@s.Name" style="width:100%;height:80px;object-fit:contain" />
+                            </a>
+                        }
+                        else
+                        {
+                            <img src="@LogoSrc(s)" alt="@s.Name" style="width:100%;height:80px;object-fit:contain" />
+                        }
+                    </div>
                     <div style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black);margin-top:8px;text-align:center">@s.Name</div>
                     @if (!string.IsNullOrEmpty(s.ContactName))
                     {
@@ -49,6 +51,17 @@
 </div>
 
 <style>
+    .sponsors-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+    @@media (min-width: 480px) {
+        .sponsors-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @@media (min-width: 700px) {
+        .sponsors-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
+    }
     .sponsor-tile {
         background: var(--panel-bg);
         border: 3px solid var(--black);
@@ -58,12 +71,17 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        min-width: 140px;
-        transition: transform .1s;
+    }
+    .sponsor-logo-box {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
     .sponsor-logo-link {
         display: block;
         text-decoration: none;
+        width: 100%;
     }
     .sponsor-logo-link:hover img {
         opacity: .85;

--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -28,12 +28,63 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_framework/blazor.server.js"></script>
+    <div id="components-reconnect-modal">
+        <div class="ccn-reconnect-banner ccn-reconnect-show">📶 Reconnecting…</div>
+        <div class="ccn-reconnect-banner ccn-reconnect-failed">
+            <span>Connection lost.</span>
+            <button class="ccn-reconnect-reload-btn" onclick="location.reload()">Reload</button>
+            <span id="ccn-reload-countdown"></span>
+        </div>
+        <div class="ccn-reconnect-banner ccn-reconnect-rejected">Session expired — reloading…</div>
+    </div>
+    <script src="_framework/blazor.server.js" autostart="false"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/board.js?v=3"></script>
-    <script src="js/connection-indicator.js"></script>
     <script src="js/install-prompt.js"></script>
     <script>
+        Blazor.start({
+            reconnectionOptions: {
+                maxRetries: 12,
+                retryIntervalMilliseconds: function (n) {
+                    return Math.min(n * 2000 + 1000, 20000);
+                }
+            }
+        });
+
+        (function () {
+            var modal = document.getElementById('components-reconnect-modal');
+            var countdown = document.getElementById('ccn-reload-countdown');
+            var timer = null;
+            if (!modal) return;
+
+            function clearTimer() {
+                if (timer) { clearInterval(timer); timer = null; }
+                if (countdown) countdown.textContent = '';
+            }
+
+            new MutationObserver(function () {
+                clearTimer();
+                if (modal.classList.contains('components-reconnect-rejected')) {
+                    setTimeout(function () { location.reload(); }, 1500);
+                } else if (modal.classList.contains('components-reconnect-failed')) {
+                    var secs = 8;
+                    if (countdown) countdown.textContent = '(' + secs + 's)';
+                    timer = setInterval(function () {
+                        if (--secs <= 0) { clearInterval(timer); location.reload(); }
+                        if (countdown) countdown.textContent = '(' + secs + 's)';
+                    }, 1000);
+                }
+            }).observe(modal, { attributes: true, attributeFilter: ['class'] });
+
+            document.addEventListener('visibilitychange', function () {
+                if (document.visibilityState === 'visible' &&
+                    (modal.classList.contains('components-reconnect-failed') ||
+                     modal.classList.contains('components-reconnect-rejected'))) {
+                    location.reload();
+                }
+            });
+        }());
+
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('/service-worker.js')
                 .catch(function(err) { console.warn('SW registration failed:', err); });

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -211,7 +211,6 @@
             <img src="/img/ccn-logo-nav.png" alt="Camp Clot Not" style="height:36px;width:auto;object-fit:contain" />
             <span style="font-family:'Fredoka One',cursive;font-size:10px;color:var(--color-primary);letter-spacing:2px;text-transform:uppercase;line-height:1;margin-left:8px">SUPER PARTY '26</span>
         </div>
-        <ConnectionIndicator />
     </div>
 </div>
 
@@ -222,7 +221,6 @@
             <img src="/img/ccn-logo-nav.png" alt="Camp Clot Not" style="height:42px;width:auto;object-fit:contain" />
             <span style="font-family:'Fredoka One',cursive;font-size:11px;color:var(--color-primary);letter-spacing:2px;text-transform:uppercase;line-height:1;margin-left:8px">SUPER PARTY '26</span>
         </div>
-        <ConnectionIndicator />
     </div>
 
     <AuthorizeView>

--- a/CampClotNot/wwwroot/app.css
+++ b/CampClotNot/wwwroot/app.css
@@ -24,3 +24,53 @@ h1, h2, h3, .mud-typography-h1, .mud-typography-h2, .mud-typography-h3, .mud-app
     right: 0.75rem;
     top: 0.5rem;
 }
+
+/* ── Graceful reconnect banner ──────────────────────────────────── */
+#components-reconnect-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+}
+#components-reconnect-modal.components-reconnect-show,
+#components-reconnect-modal.components-reconnect-failed,
+#components-reconnect-modal.components-reconnect-rejected {
+    display: block;
+}
+.ccn-reconnect-banner {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 9px 16px;
+    font-family: 'Fredoka One', cursive;
+    font-size: 14px;
+    border-bottom: 3px solid #1A1A1A;
+}
+#components-reconnect-modal.components-reconnect-show .ccn-reconnect-show {
+    display: flex;
+    background: #F5C800;
+    color: #1A1A1A;
+}
+#components-reconnect-modal.components-reconnect-failed .ccn-reconnect-failed {
+    display: flex;
+    background: #D12B2B;
+    color: white;
+}
+#components-reconnect-modal.components-reconnect-rejected .ccn-reconnect-rejected {
+    display: flex;
+    background: #D12B2B;
+    color: white;
+}
+.ccn-reconnect-reload-btn {
+    font-family: 'Fredoka One', cursive;
+    font-size: 12px;
+    padding: 3px 12px;
+    background: rgba(255,255,255,.9);
+    color: #D12B2B;
+    border: 2px solid white;
+    border-radius: 4px;
+    cursor: pointer;
+}


### PR DESCRIPTION
Reconnect UX:
- Remove ConnectionIndicator from mobile + desktop nav headers (dot never turned red — invokeMethodAsync can't reach .NET when circuit is down)
- Remove connection-indicator.js script from _Layout.cshtml
- Add CSS-driven #components-reconnect-modal with three states: yellow reconnecting banner, red failed banner (8s auto-reload countdown + Reload button), red rejected banner (1.5s auto-reload)
- Switch blazor.server.js to autostart=false; configure Blazor.start() with exponential backoff (maxRetries:12, up to 20s between attempts)
- Add visibilitychange listener: silently reload if PWA is foregrounded after circuit failure

Mobile layout:
- Hub/Schedule: hide location thumbnail in mobile card rows to reduce vertical clutter
- Dashboard sponsors: replace variable-height flex wrap with uniform-cell CSS grid (auto-fill, 90px min) so logos of different aspect ratios align
- Hub/Sponsors: single-column on mobile, 2-col at 480px+, auto-fill grid at 700px+; standardize logo height with fixed container
- Admin/ScheduleItemTypes: overflow-x:auto on table + hide SystemName column on mobile (fits without scroll)
- Admin/Schedule: overflow-x:auto on table + hide description/group-assignment sub-rows and location thumbnail on mobile to reduce row height