### PR TITLE
fix(v1.0.0-rc.1): reconnect banner round 2 + admin schedule mobile card view

### DIFF
--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -337,7 +337,6 @@
                     </table>
                     </div>
                 </div>
-                </div>
             }
         </div>
 

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -14,8 +14,14 @@
 
 <style>
     @@media (max-width: 699px) {
-        .admin-sched-desc  { display: none; }
+        .admin-sched-desc    { display: none; }
         .admin-sched-loc-img { display: none; }
+        .admin-sched-table   { display: none; }
+        .admin-sched-cards   { display: flex; flex-direction: column; gap: 10px; }
+        .admin-sched-form    { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+    }
+    @@media (min-width: 700px) {
+        .admin-sched-cards { display: none; }
     }
 </style>
 
@@ -25,7 +31,7 @@
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 340px;min-width:280px">
+        <div class="admin-sched-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 340px;min-width:280px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Event" : "Edit Event")</h3>
 
             <div style="margin-bottom:14px">
@@ -209,7 +215,44 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                @* ── Mobile card list ── *@
+                <div class="admin-sched-cards">
+                    @foreach (var ev in _events)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px">
+                            <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px">
+                                <div style="flex:1;min-width:0">
+                                    <div style="font-size:11px;color:var(--text-light);font-weight:700;margin-bottom:3px">
+                                        @ev.CampDay.ToString("ddd M/d") &nbsp;·&nbsp; @ev.StartTime.ToString("h:mm tt")@(ev.EndTime.HasValue ? $" – {ev.EndTime.Value.ToString("h:mm tt")}" : "")
+                                    </div>
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black);line-height:1.2;margin-bottom:6px">
+                                        @ev.Title
+                                    </div>
+                                    <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
+                                        <span style="font-size:11px;padding:2px 8px;border-radius:4px;background:@ItemTypeBadgeColor(ev.ScheduleItemType?.SystemName);color:white;font-family:'Fredoka One',cursive">
+                                            @DisplayItemType(ev.ScheduleItemType)
+                                        </span>
+                                        @if (ev.Location is not null)
+                                        {
+                                            <span style="font-size:11px;color:var(--text-mid)">@ev.Location.Name@(!string.IsNullOrEmpty(ev.LocationOther) ? $" + {ev.LocationOther}" : "")</span>
+                                        }
+                                        else if (!string.IsNullOrEmpty(ev.LocationOther))
+                                        {
+                                            <span style="font-size:11px;color:var(--text-mid)">@ev.LocationOther</span>
+                                        }
+                                    </div>
+                                </div>
+                                <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => StartEdit(ev)">Edit</button>
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(ev)">Del</button>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                @* ── Desktop table ── *@
+                <div class="admin-sched-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <div style="overflow-x:auto">
                     <table style="width:100%;border-collapse:collapse;min-width:520px">
                         <colgroup>
@@ -293,6 +336,7 @@
                         </tbody>
                     </table>
                     </div>
+                </div>
                 </div>
             }
         </div>

--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="app.css" rel="stylesheet" />
+    <link href="app.css?v=2" rel="stylesheet" />
     @RenderSection("HeadOutlet", required: false)
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#3d0066" />
@@ -22,20 +22,25 @@
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
 </head>
 <body>
+    <%-- Reconnect banner — must be first child so position:fixed top:0 is never blocked --%>
+    <div id="components-reconnect-modal" style="display:none;position:fixed;top:0;left:0;right:0;z-index:9999">
+        <div id="ccn-banner-show"     style="display:none;align-items:center;justify-content:center;gap:10px;padding:9px 16px;background:#F5C800;color:#1A1A1A;font-family:'Fredoka One',cursive;font-size:14px;font-weight:700;border-bottom:3px solid #1A1A1A">
+            📶 Reconnecting…
+        </div>
+        <div id="ccn-banner-failed"   style="display:none;align-items:center;justify-content:center;gap:10px;padding:9px 16px;background:#D12B2B;color:white;font-family:'Fredoka One',cursive;font-size:14px;font-weight:700;border-bottom:3px solid #1A1A1A">
+            <span>Connection lost.</span>
+            <button onclick="location.reload()" style="font-family:'Fredoka One',cursive;font-size:12px;padding:3px 12px;background:rgba(255,255,255,.9);color:#D12B2B;border:2px solid white;border-radius:4px;cursor:pointer">Reload</button>
+            <span id="ccn-reload-countdown" style="font-size:12px;opacity:.8"></span>
+        </div>
+        <div id="ccn-banner-rejected" style="display:none;align-items:center;justify-content:center;gap:10px;padding:9px 16px;background:#D12B2B;color:white;font-family:'Fredoka One',cursive;font-size:14px;font-weight:700;border-bottom:3px solid #1A1A1A">
+            Session expired — reloading…
+        </div>
+    </div>
     @RenderBody()
     <div id="blazor-error-ui">
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
-    </div>
-    <div id="components-reconnect-modal">
-        <div class="ccn-reconnect-banner ccn-reconnect-show">📶 Reconnecting…</div>
-        <div class="ccn-reconnect-banner ccn-reconnect-failed">
-            <span>Connection lost.</span>
-            <button class="ccn-reconnect-reload-btn" onclick="location.reload()">Reload</button>
-            <span id="ccn-reload-countdown"></span>
-        </div>
-        <div class="ccn-reconnect-banner ccn-reconnect-rejected">Session expired — reloading…</div>
     </div>
     <script src="_framework/blazor.server.js" autostart="false"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
@@ -52,10 +57,30 @@
         });
 
         (function () {
-            var modal = document.getElementById('components-reconnect-modal');
-            var countdown = document.getElementById('ccn-reload-countdown');
-            var timer = null;
+            var modal    = document.getElementById('components-reconnect-modal');
+            var bShow    = document.getElementById('ccn-banner-show');
+            var bFailed  = document.getElementById('ccn-banner-failed');
+            var bReject  = document.getElementById('ccn-banner-rejected');
+            var countdown= document.getElementById('ccn-reload-countdown');
+            var timer    = null;
             if (!modal) return;
+
+            var FLEX = 'flex', NONE = 'none';
+
+            function hideAll() {
+                modal.style.display   = NONE;
+                bShow.style.display   = NONE;
+                bFailed.style.display = NONE;
+                bReject.style.display = NONE;
+            }
+
+            function showOnly(banner) {
+                modal.style.display   = 'block';
+                bShow.style.display   = NONE;
+                bFailed.style.display = NONE;
+                bReject.style.display = NONE;
+                banner.style.display  = FLEX;
+            }
 
             function clearTimer() {
                 if (timer) { clearInterval(timer); timer = null; }
@@ -64,15 +89,22 @@
 
             new MutationObserver(function () {
                 clearTimer();
-                if (modal.classList.contains('components-reconnect-rejected')) {
+                var cl = modal.classList;
+                if (cl.contains('components-reconnect-rejected')) {
+                    showOnly(bReject);
                     setTimeout(function () { location.reload(); }, 1500);
-                } else if (modal.classList.contains('components-reconnect-failed')) {
+                } else if (cl.contains('components-reconnect-failed')) {
+                    showOnly(bFailed);
                     var secs = 8;
-                    if (countdown) countdown.textContent = '(' + secs + 's)';
+                    countdown.textContent = '(' + secs + 's)';
                     timer = setInterval(function () {
                         if (--secs <= 0) { clearInterval(timer); location.reload(); }
-                        if (countdown) countdown.textContent = '(' + secs + 's)';
+                        countdown.textContent = '(' + secs + 's)';
                     }, 1000);
+                } else if (cl.contains('components-reconnect-show')) {
+                    showOnly(bShow);
+                } else {
+                    hideAll();
                 }
             }).observe(modal, { attributes: true, attributeFilter: ['class'] });
 


### PR DESCRIPTION
Follow-up to #131 — two fixes identified after the first merge.

## Reconnect banner rewrite
The CSS-class-based show/hide from the first pass was being overridden by MudBlazor, causing all three banner states to render simultaneously as unstyled plain text. Fix:
- Switch all banner visibility to JS `element.style.display` via MutationObserver — bypasses the CSS cascade entirely
- Move `#components-reconnect-modal` to be the first child of `<body>` (before `@RenderBody()`) so `position:fixed;top:0` is never blocked by an ancestor element
- All styles are now inline on the HTML elements themselves — no class dependency
- `app.css?v=2` cache-bust

## Admin/Schedule mobile card view
`overflow-x:auto` from #131 required horizontal scrolling — users landed on the left side and had to scroll to reach Edit/Del. Fix:
- Add `.admin-sched-cards` mobile card list (`≤699px`): shows day · time, title, type badge, location, and stacked Edit/Del buttons per item — no scrolling needed
- Hide desktop table on mobile via `.admin-sched-table` class
- Fix form panel overflowing narrow screens: was `flex: 0 0 340px` which is 12px wider than a 360px phone's content area; CSS now overrides to `flex: 0 0 100%` on mobile

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_