### PR TITLE
v1.0.0-rc.1 — Reconnect UX + mobile admin polish

### DIFF
--- a/CampClotNot/Pages/Admin/Activities.razor
+++ b/CampClotNot/Pages/Admin/Activities.razor
@@ -6,6 +6,17 @@
 
 <PageTitle>Activities — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-act-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-act-table { display: none; }
+        .admin-act-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-act-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 4px">🎲 Activities</h2>
     <p style="font-size:13px;color:var(--text-light);margin:0 0 20px">
@@ -15,7 +26,7 @@
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
+        <div class="admin-act-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Activity" : "Edit Activity")</h3>
 
             <div style="margin-bottom:14px">
@@ -64,7 +75,31 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                <div class="admin-act-cards">
+                    @foreach (var a in _activities)
+                    {
+                        var locName = a.LocationId.HasValue ? _locations.FirstOrDefault(l => l.LocationId == a.LocationId.Value)?.Name : null;
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:flex-start;gap:8px">
+                            <div style="flex:1;min-width:0">
+                                <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black);margin-bottom:4px">@a.Name</div>
+                                @if (!string.IsNullOrEmpty(a.Description))
+                                {
+                                    <div style="font-size:12px;color:var(--text-mid);margin-bottom:3px">@a.Description</div>
+                                }
+                                @if (locName is not null)
+                                {
+                                    <div style="font-size:11px;color:var(--text-light)">📍 @locName</div>
+                                }
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => StartEdit(a)">Edit</button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(a)">Del</button>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-act-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
                         <thead>
                             <tr style="background:var(--black)">
@@ -100,6 +135,7 @@
 </div>
 
 @code {
+
     private List<Activity> _activities = new();
     private List<Location> _locations = new();
     private bool _loading = true;

--- a/CampClotNot/Pages/Admin/Games.razor
+++ b/CampClotNot/Pages/Admin/Games.razor
@@ -6,6 +6,19 @@
 
 <PageTitle>Game Admin — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-gm-table   { display: none; }
+        .admin-gm-cards   { display: flex; flex-direction: column; gap: 10px; }
+        .admin-mg-table   { display: none; }
+        .admin-mg-cards   { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-gm-cards { display: none; }
+        .admin-mg-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">🎮 Game Admin</h2>
 
@@ -23,7 +36,25 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                <div class="admin-gm-cards">
+                    @foreach (var space in _spaces)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:10px 14px;display:flex;align-items:center;gap:10px">
+                            <div style="font-family:'Fredoka One',cursive;font-size:20px;color:var(--text-light);min-width:28px;text-align:center">@space.SpaceIndex</div>
+                            <div style="flex:1;min-width:0">
+                                <span style="@($"background:{SpaceColor(space.CategorySystemName)};color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px")">
+                                    @SpaceIcon(space.CategorySystemName) @space.CategorySystemName
+                                </span>
+                                @if (!string.IsNullOrEmpty(space.ActivityName))
+                                {
+                                    <div style="font-size:13px;font-weight:700;margin-top:4px">@space.ActivityName</div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-gm-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
                         <thead>
                             <tr style="background:var(--black)">
@@ -140,7 +171,48 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;max-width:640px">
+                <div class="admin-mg-cards">
+                    @for (var day = 1; day <= 5; day++)
+                    {
+                        var d = day;
+                        var script = _miniGameScripts.FirstOrDefault(s => s.CampDay == d);
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px">
+                            <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px">
+                                <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">Day @d</div>
+                                @if (script?.IsTriggered == true)
+                                {
+                                    <span style="background:#27AE60;color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px">✓ Triggered</span>
+                                }
+                                else if (script is not null)
+                                {
+                                    <span style="background:#E67E22;color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px">Scripted</span>
+                                }
+                                else
+                                {
+                                    <span style="background:#95A5A6;color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px">Not set</span>
+                                }
+                            </div>
+                            @if (script?.IsTriggered == true)
+                            {
+                                <div style="font-size:13px;color:var(--text-mid)">@script.ActivityName</div>
+                            }
+                            else
+                            {
+                                <select value="@(script?.ActivityId.ToString() ?? "")"
+                                        @onchange="async e => { if (Guid.TryParse(e.Value?.ToString(), out var g)) await OnMiniGameActivityChanged(d, g); }"
+                                        style="width:100%;padding:7px 10px;background:var(--bg-base);border:2px solid var(--black);border-radius:6px;font-size:13px;font-family:'Nunito',sans-serif;font-weight:600;color:var(--text-dark);box-shadow:2px 2px 0 var(--black);outline:none;cursor:pointer;box-sizing:border-box">
+                                    <option value="">— pick activity —</option>
+                                    @foreach (var activity in _miniGameActivities)
+                                    {
+                                        <option value="@activity.ActivityId">@activity.Name</option>
+                                    }
+                                </select>
+                            }
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-mg-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;max-width:640px">
                     <table style="border-collapse:collapse;width:100%">
                         <thead>
                             <tr style="background:var(--black)">

--- a/CampClotNot/Pages/Admin/Groups.razor
+++ b/CampClotNot/Pages/Admin/Groups.razor
@@ -6,13 +6,24 @@
 
 <PageTitle>Manage Groups — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-grp-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-grp-table { display: none; }
+        .admin-grp-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-grp-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">👥 Groups</h2>
 
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
+        <div class="admin-grp-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editing is null ? "Add Group" : "Edit Group")</h3>
 
             <div style="margin-bottom:14px">
@@ -81,7 +92,29 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                <div class="admin-grp-cards">
+                    @foreach (var g in _groups)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:8px">
+                            <div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0">
+                                <div style="@($"width:28px;height:28px;border-radius:6px;border:2px solid var(--black);background:{g.Color};flex-shrink:0")"></div>
+                                <div style="min-width:0">
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">@g.Name <span style="font-size:12px;color:var(--text-light)">(@g.ShortName)</span></div>
+                                    @if (g.TokenAssetPath is not null)
+                                    {
+                                        <img src="@g.TokenAssetPath" style="width:22px;height:22px;object-fit:contain;margin-top:2px" />
+                                    }
+                                </div>
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => StartEdit(g)">Edit</button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(g)">Del</button>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-grp-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
                         <thead>
                             <tr style="background:var(--black)">

--- a/CampClotNot/Pages/Admin/Locations.razor
+++ b/CampClotNot/Pages/Admin/Locations.razor
@@ -5,13 +5,24 @@
 
 <PageTitle>Locations — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-loc-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-loc-table { display: none; }
+        .admin-loc-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-loc-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">📍 Locations</h2>
 
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
+        <div class="admin-loc-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 300px;min-width:240px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Location" : "Edit Location")</h3>
 
             <div style="margin-bottom:14px">
@@ -72,7 +83,35 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                <div class="admin-loc-cards">
+                    @foreach (var loc in _locations)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:8px">
+                            <div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0">
+                                @if (loc.ImageData is not null)
+                                {
+                                    <img src="/location-image/@loc.LocationId"
+                                         style="width:40px;height:32px;object-fit:cover;border-radius:4px;border:2px solid var(--black);flex-shrink:0;cursor:zoom-in"
+                                         @onclick='() => _lightboxSrc = $"/location-image/{loc.LocationId}"' />
+                                }
+                                <div style="min-width:0">
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">@loc.Name</div>
+                                    @if (!string.IsNullOrEmpty(loc.Description))
+                                    {
+                                        <div style="font-size:12px;color:var(--text-mid)">@loc.Description</div>
+                                    }
+                                    <div style="font-size:11px;color:var(--text-light)">Order: @loc.SortOrder</div>
+                                </div>
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => StartEdit(loc)">Edit</button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(loc)">Del</button>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-loc-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
                         <thead>
                             <tr style="background:var(--black)">

--- a/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
+++ b/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
@@ -9,7 +9,12 @@
 
 <style>
     @@media (max-width: 699px) {
-        .sit-col-sysname { display: none; }
+        .admin-sit-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-sit-table { display: none; }
+        .admin-sit-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-sit-cards { display: none; }
     }
 </style>
 
@@ -31,7 +36,7 @@
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
+        <div class="admin-sit-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Type" : "Edit Type")</h3>
 
             <div style="margin-bottom:14px">
@@ -78,7 +83,36 @@
             }
             else
             {
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;margin-bottom:24px">
+                <div class="admin-sit-cards">
+                    @foreach (var t in _types)
+                    {
+                        var enabled = _enabledIds.Contains(t.ScheduleItemTypeId);
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:8px">
+                            <div style="flex:1;min-width:0">
+                                <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">
+                                    <span style="color:var(--text-light);font-size:12px;margin-right:6px">@t.SortOrder ·</span>@t.Name
+                                </div>
+                                @if (!string.IsNullOrEmpty(t.Description))
+                                {
+                                    <div style="font-size:12px;color:var(--text-mid)">@t.Description</div>
+                                }
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0;align-items:flex-end">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:@(enabled ? "#27AE60" : "transparent");color:@(enabled ? "white" : "var(--text-dark)")"
+                                        @onclick="() => ToggleEventTypeAsync(t.ScheduleItemTypeId, !enabled)">
+                                    @(enabled ? "✓ On" : "Off")
+                                </button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 10px" @onclick="() => StartEdit(t)">Edit</button>
+                                @if (string.IsNullOrEmpty(t.SystemName) || !IsBuiltIn(t.SystemName))
+                                {
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 10px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(t)">Del</button>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-sit-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden;margin-bottom:24px">
                     <div style="overflow-x:auto">
                     <table style="width:100%;border-collapse:collapse;min-width:360px">
                         <thead>

--- a/CampClotNot/Pages/Admin/Sponsors.razor
+++ b/CampClotNot/Pages/Admin/Sponsors.razor
@@ -5,13 +5,24 @@
 
 <PageTitle>Sponsors — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-spo-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-spo-table { display: none; }
+        .admin-spo-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-spo-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">🏆 Sponsors</h2>
 
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Form panel ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
+        <div class="admin-spo-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">@(_editingId == Guid.Empty ? "Add Sponsor" : "Edit Sponsor")</h3>
 
             <div style="margin-bottom:14px">
@@ -94,6 +105,30 @@
             }
             else
             {
+                <div class="admin-spo-cards">
+                    @foreach (var s in _sponsors)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:8px">
+                            <div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0">
+                                <img src="@LogoSrc(s)" alt="@s.Name"
+                                     style="height:36px;width:48px;object-fit:contain;border:1px solid #E8E0CC;border-radius:4px;background:white;padding:2px;flex-shrink:0" />
+                                <div style="min-width:0">
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">@s.Name</div>
+                                    @if (!string.IsNullOrWhiteSpace(s.Website))
+                                    {
+                                        <div style="font-size:11px;color:var(--text-light);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">@s.Website</div>
+                                    }
+                                </div>
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => StartEdit(s)">Edit</button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#D12B2B;color:white" @onclick="() => DeleteAsync(s)">Del</button>
+                            </div>
+                        </div>
+                    }
+                </div>
+
+                <div class="admin-spo-table">
                 <div style="font-size:11px;color:var(--text-light);margin-bottom:6px">Drag rows to reorder. Changes save immediately.</div>
                 <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <table style="width:100%;border-collapse:collapse">
@@ -141,6 +176,7 @@
                             }
                         </tbody>
                     </table>
+                </div>
                 </div>
             }
         </div>

--- a/CampClotNot/Pages/Admin/Users.razor
+++ b/CampClotNot/Pages/Admin/Users.razor
@@ -8,13 +8,24 @@
 
 <PageTitle>Manage Users — Camp Clot Not</PageTitle>
 
+<style>
+    @@media (max-width: 699px) {
+        .admin-usr-form  { flex: 0 0 100% !important; max-width: 100% !important; min-width: 0 !important; }
+        .admin-usr-table { display: none; }
+        .admin-usr-cards { display: flex; flex-direction: column; gap: 10px; }
+    }
+    @@media (min-width: 700px) {
+        .admin-usr-cards { display: none; }
+    }
+</style>
+
 <div style="padding: 0 16px 100px">
     <h2 style="font-family:'Fredoka One',cursive;font-size:22px;margin:0 0 20px">👤 User Accounts</h2>
 
     <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
 
         @* ── Create Account form ── *@
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
+        <div class="admin-usr-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);padding:20px;flex:0 0 320px;min-width:260px">
             <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0 0 16px">Create Account</h3>
 
             <div style="display:flex;gap:10px;margin-bottom:14px">
@@ -105,7 +116,46 @@
                     </select>
                 </div>
 
-                <div style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
+                <div class="admin-usr-cards">
+                    @foreach (var u in FilteredUsers)
+                    {
+                        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:3px 3px 0 var(--black);padding:12px 14px;display:flex;justify-content:space-between;align-items:flex-start;gap:8px">
+                            <div style="flex:1;min-width:0">
+                                <div style="display:flex;align-items:center;gap:8px;margin-bottom:3px;flex-wrap:wrap">
+                                    <div style="font-family:'Fredoka One',cursive;font-size:15px;color:var(--black)">@u.FirstName @u.LastName</div>
+                                    <span style="background:var(--black);color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px;flex-shrink:0">@u.UserRole.SystemName</span>
+                                    @if (!u.IsActive)
+                                    {
+                                        <span style="background:#E67E22;color:white;font-family:'Fredoka One',cursive;font-size:11px;padding:2px 8px;border-radius:4px">Inactive</span>
+                                    }
+                                </div>
+                                <div style="font-size:12px;color:var(--text-mid);overflow-wrap:break-word">@u.Email</div>
+                                @if (u.GroupId.HasValue)
+                                {
+                                    var grpName = _groups.FirstOrDefault(g => g.GroupId == u.GroupId)?.ShortName;
+                                    if (grpName is not null)
+                                    {
+                                        <div style="font-size:11px;color:var(--text-light);margin-top:2px">Group: @grpName</div>
+                                    }
+                                }
+                            </div>
+                            <div style="display:flex;flex-direction:column;gap:4px;flex-shrink:0">
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => OpenEditDialog(u)">Edit</button>
+                                <button class="ccn-btn" style="font-size:11px;padding:4px 12px" @onclick="() => OpenResetDialog(u)">Reset PW</button>
+                                @if (u.IsActive)
+                                {
+                                    <button class="ccn-btn" style="font-size:11px;padding:4px 12px;background:#E67E22;color:white" @onclick="() => DeactivateAsync(u)">Deactivate</button>
+                                }
+                            </div>
+                        </div>
+                    }
+                    @if (!FilteredUsers.Any())
+                    {
+                        <p style="color:var(--text-light);font-family:'Fredoka One',cursive;font-style:italic">No users match your search.</p>
+                    }
+                </div>
+
+                <div class="admin-usr-table" style="border:3px solid var(--black);border-radius:10px;box-shadow:4px 4px 0 var(--black);overflow:hidden">
                     <div style="overflow-x:auto">
                         <table style="width:100%;border-collapse:collapse;min-width:600px">
                             <thead>

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -140,6 +140,14 @@
         padding-bottom: env(safe-area-inset-bottom);
         align-items: flex-start;
     }
+    /* iOS PWA bug: env(safe-area-inset-bottom) reports 0 on first render then
+       jumps to ~34px on first navigation, causing the nav bar to visibly shift.
+       Force a 34px minimum in standalone mode so padding is consistent. */
+    @@media (display-mode: standalone) {
+        .nav-bottom-bar {
+            padding-bottom: max(env(safe-area-inset-bottom), 34px);
+        }
+    }
     .nav-tab {
         flex: 1;
         height: 56px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Reconnect banner** — custom `#components-reconnect-modal` with three styled states (yellow "Reconnecting…", red "Connection lost" + auto-reload countdown, red "Session expired" auto-reload); exponential backoff via `Blazor.start()`; `visibilitychange` listener silently reloads when PWA is foregrounded after circuit failure
- **Dynamic Island / notch fix** — `padding-top: env(safe-area-inset-top)` on the reconnect modal container so the banner clears the notch in PWA fullscreen mode
- **Login page** — removed stray Web Forms comment (`<%-- --%>`) that was rendering as visible text; fixed logo offset so it no longer overlaps the sign-in card on small phones
- **PWA nav bar jump fix** — `@media (display-mode: standalone)` forces `padding-bottom: max(env(safe-area-inset-bottom), 34px)` on `.nav-bottom-bar` so iOS doesn't shift the bar up on first navigation
- **Mobile card views for all admin table pages** — Activities, Groups, Locations, Sponsors, Users, ScheduleItemTypes, Games (Board Spaces + Mini-Game Scripts tabs); CSS class pattern matching Schedule.razor (`admin-xxx-form/table/cards`); form panel goes full-width; table hidden ≤699px; desktop table unchanged; Block Hit Scripts grid kept as horizontal-scroll (matrix layout doesn't map to cards)

## Test plan

- [ ] Disconnect device from network — yellow "Reconnecting…" banner appears, page content stays visible
- [ ] Let reconnect fail — red banner with Reload button and 8s countdown appears, auto-reloads
- [ ] Background the PWA app while disconnected, then reopen — app silently reloads (no error banner)
- [ ] On iPhone with Dynamic Island/notch: confirm reconnect banner is not cut off
- [ ] Login page: logo sits above sign-in card with clear gap on small phones (no overlap)
- [ ] Install as PWA, navigate between tabs — bottom nav bar stays at the same height on all tabs (no jump)
- [ ] On mobile (≤699px): open each admin page (Activities, Groups, Locations, Sponsors, Users, Schedule Types, Game Admin) — cards visible, form full-width, no table
- [ ] On desktop (≥700px): same pages — table visible, cards hidden, layout unchanged

https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_