### PR TITLE
Fix iOS PWA nav bar jump on direct-tab navigation

### DIFF
--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -139,6 +139,7 @@
         z-index: 40;
         padding-bottom: env(safe-area-inset-bottom);
         align-items: flex-start;
+        transition: padding-bottom 0.15s ease;
     }
     /* iOS PWA bug: env(safe-area-inset-bottom) reports 0 on first render then
        jumps to ~34px on first navigation, causing the nav bar to visibly shift.
@@ -333,6 +334,10 @@
 @* ── BOTTOM BAR (mobile) ─────────────────────────────────────────── *@
 <AuthorizeView>
     <Authorized>
+        @* Probe: position:fixed with bottom:env() forces iOS PWA to evaluate
+           env(safe-area-inset-bottom) accurately at all times, preventing the
+           nav bar padding-bottom from using a stale/lazy value. *@
+        <span aria-hidden="true" style="position:fixed;bottom:env(safe-area-inset-bottom);left:0;width:0;height:0;pointer-events:none;visibility:hidden;z-index:-1"></span>
         <div class="nav-bottom-bar">
             <a href="/dashboard" class="nav-tab @(IsDashboardActive() ? "active" : "")">
                 <span class="tab-icon">🏠</span>


### PR DESCRIPTION
## Summary

- Root cause: iOS WebKit lazily evaluates `env(safe-area-inset-bottom)` — it only gives an accurate value when a `position:fixed` element actively uses it for `bottom` positioning. The bottom sheets (`nav-game-sheet`, `nav-admin-sheet`) already had `bottom: calc(60px + env(safe-area-inset-bottom))`, which is why navigating via a sheet always "fixed" the bar. Direct-link tabs (Home, Schedule, Hub) navigate without opening any sheet, so no trigger existed to keep the env value accurate.
- Add a permanent invisible `<span style="position:fixed; bottom:env(safe-area-inset-bottom)">` inside the `<AuthorizeView>` block — always in the DOM when logged in, forces iOS to continuously evaluate the env value regardless of which tab is active
- Add `transition: padding-bottom 0.15s ease` on `.nav-bottom-bar` as a smooth fallback for any residual change

## Test plan

- [ ] Install app as PWA on iOS (home screen)
- [ ] Open app and tap Home, Schedule, and Hub tabs — nav bar stays at same height on all of them
- [ ] Tap Game or Admin tab (sheet opens), select an item — nav bar still at same height
- [ ] Verify no visible jump or resize of the bottom nav bar throughout normal use

https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_