### PR TITLE
Fix iOS PWA nav bar jump: JS-captured CSS var instead of inline env()

### DIFF
--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -46,6 +46,27 @@
     <script src="js/board.js?v=3"></script>
     <script src="js/install-prompt.js"></script>
     <script>
+        // Capture env(safe-area-inset-bottom) as a CSS custom property via JS so
+        // that nav bar CSS reads a static pixel value (var(--sai-b)) rather than
+        // calling env() inline — iOS PWA lazily re-evaluates env() on Blazor
+        // re-renders, causing the nav bar to jump. A JS-measured value is stable.
+        (function () {
+            var probe = document.createElement('div');
+            probe.style.cssText = 'position:fixed;bottom:0;left:0;width:0;height:0;padding-bottom:env(safe-area-inset-bottom,0px);pointer-events:none;visibility:hidden';
+            function snapSAI() {
+                document.body.appendChild(probe);
+                var v = parseFloat(getComputedStyle(probe).paddingBottom) || 0;
+                document.body.removeChild(probe);
+                document.documentElement.style.setProperty('--sai-b', v + 'px');
+            }
+            snapSAI();
+            requestAnimationFrame(function () { requestAnimationFrame(snapSAI); });
+            window.addEventListener('resize', snapSAI);
+            document.addEventListener('visibilitychange', function () {
+                if (document.visibilityState === 'visible') requestAnimationFrame(snapSAI);
+            });
+        }());
+
         Blazor.start({
             reconnectionOptions: {
                 maxRetries: 12,

--- a/CampClotNot/Shared/AppNav.razor
+++ b/CampClotNot/Shared/AppNav.razor
@@ -137,16 +137,15 @@
         background: var(--bg-base);
         border-top: 4px solid var(--black);
         z-index: 40;
-        padding-bottom: env(safe-area-inset-bottom);
+        /* Use JS-captured CSS var so iOS never re-evaluates env() during
+           Blazor re-renders (which caused the visible nav bar jump). */
+        padding-bottom: var(--sai-b, env(safe-area-inset-bottom, 0px));
         align-items: flex-start;
         transition: padding-bottom 0.15s ease;
     }
-    /* iOS PWA bug: env(safe-area-inset-bottom) reports 0 on first render then
-       jumps to ~34px on first navigation, causing the nav bar to visibly shift.
-       Force a 34px minimum in standalone mode so padding is consistent. */
     @@media (display-mode: standalone) {
         .nav-bottom-bar {
-            padding-bottom: max(env(safe-area-inset-bottom), 34px);
+            padding-bottom: max(var(--sai-b, 34px), 34px);
         }
     }
     .nav-tab {
@@ -334,10 +333,6 @@
 @* ── BOTTOM BAR (mobile) ─────────────────────────────────────────── *@
 <AuthorizeView>
     <Authorized>
-        @* Probe: position:fixed with bottom:env() forces iOS PWA to evaluate
-           env(safe-area-inset-bottom) accurately at all times, preventing the
-           nav bar padding-bottom from using a stale/lazy value. *@
-        <span aria-hidden="true" style="position:fixed;bottom:env(safe-area-inset-bottom);left:0;width:0;height:0;pointer-events:none;visibility:hidden;z-index:-1"></span>
         <div class="nav-bottom-bar">
             <a href="/dashboard" class="nav-tab @(IsDashboardActive() ? "active" : "")">
                 <span class="tab-icon">🏠</span>


### PR DESCRIPTION
## Summary

- **Root cause:** iOS WebKit re-evaluates `env(safe-area-inset-bottom)` inline in CSS whenever Blazor re-renders the AppNav component (e.g. to update the active tab highlight). At the moment of that re-render, iOS can return a stale/lazy value — causing the nav bar to visibly jump in height on direct-link tabs (Home, Schedule, Hub) but not on sheet-based tabs (Game, Admin), since sheet interactions trigger a separate layout event that stabilizes the value.
- **Fix:** Capture `env(safe-area-inset-bottom)` once via JavaScript (using `getComputedStyle` which forces a synchronous layout and always returns the correct value) and store it as the CSS custom property `--sai-b`. The nav bar CSS now reads `var(--sai-b)` — a plain pixel value — instead of calling `env()` directly, so there is nothing for iOS to lazily re-evaluate during Blazor re-renders.
- Double `requestAnimationFrame` re-reads the value after the first frame settles; `visibilitychange` re-reads when the PWA is brought back to foreground; `resize` handles orientation changes.
- The `0.15s` transition and `max(34px)` standalone guard are kept as backstops.
- Removes the probe `<span>` from the previous attempt (superseded by this approach).

## Test plan

- [ ] Install app as PWA on iOS (add to home screen)
- [ ] Tap Home, Schedule, and Hub tabs repeatedly — nav bar stays at the same height on all of them, no jump
- [ ] Tap Game or Admin (sheet opens), select an item — nav bar still at same height
- [ ] Background the app, wait a moment, reopen — nav bar still correct height
- [ ] Rotate device if possible — nav bar adjusts correctly

https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_