### PR TITLE
Fix nav CSS cache, double header, desktop install prompt

### DIFF
--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="app.css?v=2" rel="stylesheet" />
+    <link href="app.css?v=3" rel="stylesheet" />
     @RenderSection("HeadOutlet", required: false)
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#3d0066" />

--- a/CampClotNot/wwwroot/js/install-prompt.js
+++ b/CampClotNot/wwwroot/js/install-prompt.js
@@ -4,6 +4,9 @@ window.installPrompt = {
         var dismissed = localStorage.getItem('ccn_install_dismissed') === '1';
         if (dismissed) return;
 
+        var isMobile = /android|iphone|ipad|ipod/i.test(navigator.userAgent) || window.innerWidth < 1024;
+        if (!isMobile) return;
+
         window.addEventListener('beforeinstallprompt', function(e) {
             e.preventDefault();
             window.installPrompt._deferred = e;

--- a/CampClotNot/wwwroot/service-worker.js
+++ b/CampClotNot/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ccn-shell-v2';
+const CACHE_NAME = 'ccn-shell-v3';
 const SHELL_ASSETS = [
     '/offline.html',
     '/app.css',


### PR DESCRIPTION
## Summary

- Move all AppNav CSS to `app.css` so Blazor's DOM patching can never touch nav styles (root cause of iOS PWA nav bar jump)
- Bump service worker to `ccn-shell-v3` and `app.css?v=3` so PWA clients discard the old cached stylesheet and load the nav rules correctly — fixes the double-header on both mobile and desktop after the CSS move
- Suppress install prompt on desktop — `beforeinstallprompt` fires on desktop Chrome too; added mobile UA + viewport guard before showing the banner
- Parallelize Schedule page `OnInitializedAsync` (5 sequential DB calls → `Task.WhenAll`)
- Add `IMemoryCache` to `LocationService`, `ScheduleItemTypeService`, `MiniGameService.GetActivitiesAsync` (5min TTL, write-through invalidation)
- Fix ThemeHead FAB `env(safe-area-inset-bottom)` → `var(--sai-b)`

## Test plan

- [ ] iOS PWA: tap Home / Schedule / Hub tabs directly — nav bar stays pinned, no jump
- [ ] Desktop: both headers no longer show simultaneously
- [ ] Desktop: install prompt no longer appears
- [ ] Schedule page second visit noticeably faster than first
- [ ] Admin edits to locations / schedule item types / activities reflect immediately

https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_