### PR TITLE
Fix iOS PWA nav bar jump — MainLayout content wrapper env() → var(--sai-b)

### DIFF
--- a/CampClotNot/Shared/MainLayout.razor
+++ b/CampClotNot/Shared/MainLayout.razor
@@ -12,7 +12,7 @@
 
 <AppNav OnLeaderboardClick="@(() => _showProjector = true)" />
 
-<div style="padding:20px 18px calc(80px + env(safe-area-inset-bottom))">
+<div style="padding:20px 18px calc(80px + var(--sai-b, 0px))">
     @Body
 </div>
 


### PR DESCRIPTION
## Summary

One line. `MainLayout.razor` line 15 — the wrapper div around `@Body` — had `env(safe-area-inset-bottom)` in an inline style. Every Blazor navigation patches this div, which causes iOS WebKit to re-evaluate `env()` and return a stale value, shifting the content area and making the nav bar appear to jump.

Changed to `var(--sai-b, 0px)` which uses the stable pixel value already captured by the static probe at startup. No effect on desktop, Android, or regular iOS Safari — `env()` is `0px` on all those so the result is identical.

## Test plan

- [ ] iOS PWA: tap Home / Schedule / Hub tabs directly — nav bar stays pinned, no jump
- [ ] Desktop and Android: layout unchanged

https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXWrtEjuNz57ZNFvHXmUpU)_