### PR TITLE
Merge dev to main — push notifications + persistent sessions

### DIFF
--- a/CampClotNot/CampClotNot.csproj
+++ b/CampClotNot/CampClotNot.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Lib.Net.Http.WebPush" Version="3.3.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.*" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />

--- a/CampClotNot/CampClotNot.csproj
+++ b/CampClotNot/CampClotNot.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Lib.Net.Http.WebPush" Version="3.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.*" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />

--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -51,6 +51,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<IncidentReport> IncidentReports => Set<IncidentReport>();
     public DbSet<Sponsor> Sponsors => Set<Sponsor>();
     public DbSet<CampDocument> CampDocuments => Set<CampDocument>();
+    public DbSet<PushSubscription> PushSubscriptions => Set<PushSubscription>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/CampClotNot/Data/AppDbContext.cs
+++ b/CampClotNot/Data/AppDbContext.cs
@@ -1,10 +1,12 @@
 using CampClotNot.Data.Entities;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace CampClotNot.Data;
 
-public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options), IDataProtectionKeyContext
 {
+    public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
     // Event structure
     public DbSet<EventType> EventTypes => Set<EventType>();
     public DbSet<Event> Events => Set<Event>();

--- a/CampClotNot/Data/Entities/PushSubscription.cs
+++ b/CampClotNot/Data/Entities/PushSubscription.cs
@@ -1,0 +1,11 @@
+namespace CampClotNot.Data.Entities;
+
+public class PushSubscription
+{
+    public Guid PushSubscriptionId { get; set; }
+    public string Endpoint { get; set; } = "";
+    public string P256dh { get; set; } = "";
+    public string Auth { get; set; } = "";
+    public Guid? UserId { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/CampClotNot/Migrations/20260620145749_AddPushSubscriptions.Designer.cs
+++ b/CampClotNot/Migrations/20260620145749_AddPushSubscriptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620145749_AddPushSubscriptions")]
+    partial class AddPushSubscriptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260620145749_AddPushSubscriptions.cs
+++ b/CampClotNot/Migrations/20260620145749_AddPushSubscriptions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPushSubscriptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PushSubscriptions",
+                columns: table => new
+                {
+                    PushSubscriptionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Endpoint = table.Column<string>(type: "text", nullable: false),
+                    P256dh = table.Column<string>(type: "text", nullable: false),
+                    Auth = table.Column<string>(type: "text", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PushSubscriptions", x => x.PushSubscriptionId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PushSubscriptions");
+        }
+    }
+}

--- a/CampClotNot/Migrations/20260620150347_PersistDataProtectionKeys.Designer.cs
+++ b/CampClotNot/Migrations/20260620150347_PersistDataProtectionKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CampClotNot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CampClotNot.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620150347_PersistDataProtectionKeys")]
+    partial class PersistDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CampClotNot/Migrations/20260620150347_PersistDataProtectionKeys.cs
+++ b/CampClotNot/Migrations/20260620150347_PersistDataProtectionKeys.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CampClotNot.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersistDataProtectionKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -121,5 +121,6 @@ if ('serviceWorker' in navigator) {
                 .catch(function(err) { console.warn('SW registration failed:', err); });
         }
     </script>
+    <script src="/js/push-notifications.js"></script>
 </body>
 </html>

--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -71,6 +71,7 @@ try
     builder.Services.AddScoped<SponsorService>();
     builder.Services.AddScoped<DocumentService>();
     builder.Services.AddScoped<AuthService>();
+    builder.Services.AddSingleton<PushNotificationService>();
     builder.Services.AddScoped<SeedService>();
 
     builder.Services.AddHttpContextAccessor();
@@ -232,6 +233,28 @@ try
         return Results.File(doc.Data, doc.ContentType, doc.OriginalFileName ?? $"{doc.Title}.pdf");
     }).RequireAuthorization();
 
+    app.MapGet("/api/vapid-public-key", (IConfiguration config) =>
+        Results.Ok(new { key = config["Vapid:PublicKey"] }));
+
+    app.MapPost("/api/push/subscribe", async (HttpContext ctx, PushNotificationService pushSvc) =>
+    {
+        var form = await ctx.Request.ReadFromJsonAsync<PushSubscribeRequest>();
+        if (form is null) return Results.BadRequest();
+        Guid? userId = null;
+        if (Guid.TryParse(ctx.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value, out var uid))
+            userId = uid;
+        await pushSvc.SubscribeAsync(form.Endpoint, form.P256dh, form.Auth, userId);
+        return Results.Ok();
+    });
+
+    app.MapPost("/api/push/unsubscribe", async (HttpContext ctx, PushNotificationService pushSvc) =>
+    {
+        var form = await ctx.Request.ReadFromJsonAsync<PushUnsubscribeRequest>();
+        if (form is null) return Results.BadRequest();
+        await pushSvc.UnsubscribeAsync(form.Endpoint);
+        return Results.Ok();
+    });
+
     app.MapHub<LiveHub>("/livehub");
     app.MapBlazorHub();
     app.MapFallbackToPage("/_Host");
@@ -254,3 +277,6 @@ static string ConvertPostgresUri(string uri)
     var userInfo = u.UserInfo.Split(':');
     return $"Host={u.Host};Port={u.Port};Database={u.AbsolutePath.TrimStart('/')};Username={userInfo[0]};Password={userInfo[1]};SSL Mode=Require;Trust Server Certificate=true";
 }
+
+record PushSubscribeRequest(string Endpoint, string P256dh, string Auth);
+record PushUnsubscribeRequest(string Endpoint);

--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -4,6 +4,7 @@ using CampClotNot.Repositories;
 using CampClotNot.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using MudBlazor.Services;
 using Serilog;
@@ -73,6 +74,9 @@ try
     builder.Services.AddScoped<AuthService>();
     builder.Services.AddSingleton<PushNotificationService>();
     builder.Services.AddScoped<SeedService>();
+
+    builder.Services.AddDataProtection()
+        .PersistKeysToDbContext<AppDbContext>();
 
     builder.Services.AddHttpContextAccessor();
     builder.Services.AddRazorPages();

--- a/CampClotNot/Services/AnnouncementService.cs
+++ b/CampClotNot/Services/AnnouncementService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace CampClotNot.Services;
 
-public class AnnouncementService(IDbContextFactory<AppDbContext> factory, IMemoryCache cache)
+public class AnnouncementService(IDbContextFactory<AppDbContext> factory, IMemoryCache cache, PushNotificationService pushService)
 {
     private const string FeedKey = "ann.feed";
 
@@ -58,6 +58,10 @@ public class AnnouncementService(IDbContextFactory<AppDbContext> factory, IMemor
         db.Announcements.Add(announcement);
         await db.SaveChangesAsync();
         cache.Remove(FeedKey);
+        _ = Task.Run(() => pushService.SendToAllAsync(
+            priority == AnnouncementPriority.Urgent ? $"🚨 {title}" : $"📢 {title}",
+            body.Length > 120 ? body[..117] + "..." : body,
+            "/hub/announcements"));
         return announcement;
     }
 

--- a/CampClotNot/Services/PushNotificationService.cs
+++ b/CampClotNot/Services/PushNotificationService.cs
@@ -1,0 +1,114 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CampClotNot.Data;
+using Lib.Net.Http.WebPush;
+using Lib.Net.Http.WebPush.Authentication;
+using Microsoft.EntityFrameworkCore;
+using DbPushSub = CampClotNot.Data.Entities.PushSubscription;
+
+namespace CampClotNot.Services;
+
+public class PushNotificationService
+{
+    private readonly IDbContextFactory<AppDbContext> _factory;
+    private readonly PushServiceClient _pushClient;
+    private readonly ILogger<PushNotificationService> _logger;
+
+    public PushNotificationService(
+        IDbContextFactory<AppDbContext> factory,
+        IConfiguration config,
+        ILogger<PushNotificationService> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+
+        var vapidPublic = config["Vapid:PublicKey"]!;
+        var vapidPrivate = config["Vapid:PrivateKey"]!;
+        var vapidSubject = config["Vapid:Subject"] ?? "mailto:trblair16@gmail.com";
+
+        _pushClient = new PushServiceClient();
+        _pushClient.DefaultAuthentication = new VapidAuthentication(vapidPublic, vapidPrivate)
+        {
+            Subject = vapidSubject
+        };
+    }
+
+    public async Task SubscribeAsync(string endpoint, string p256dh, string auth, Guid? userId)
+    {
+        using var db = _factory.CreateDbContext();
+        var existing = await db.PushSubscriptions
+            .FirstOrDefaultAsync(s => s.Endpoint == endpoint);
+
+        if (existing is not null)
+        {
+            existing.P256dh = p256dh;
+            existing.Auth = auth;
+            existing.UserId = userId;
+        }
+        else
+        {
+            db.PushSubscriptions.Add(new DbPushSub
+            {
+                PushSubscriptionId = Guid.NewGuid(),
+                Endpoint = endpoint,
+                P256dh = p256dh,
+                Auth = auth,
+                UserId = userId,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+        await db.SaveChangesAsync();
+    }
+
+    public async Task UnsubscribeAsync(string endpoint)
+    {
+        using var db = _factory.CreateDbContext();
+        var sub = await db.PushSubscriptions
+            .FirstOrDefaultAsync(s => s.Endpoint == endpoint);
+        if (sub is not null)
+        {
+            db.PushSubscriptions.Remove(sub);
+            await db.SaveChangesAsync();
+        }
+    }
+
+    public async Task SendToAllAsync(string title, string body, string? url = null)
+    {
+        using var db = _factory.CreateDbContext();
+        var subs = await db.PushSubscriptions.ToListAsync();
+
+        var payload = JsonSerializer.Serialize(new { title, body, url });
+
+        var stale = new List<DbPushSub>();
+        foreach (var sub in subs)
+        {
+            try
+            {
+                var pushSub = new Lib.Net.Http.WebPush.PushSubscription
+                {
+                    Endpoint = sub.Endpoint,
+                    Keys = { ["p256dh"] = sub.P256dh, ["auth"] = sub.Auth }
+                };
+                var message = new PushMessage(payload)
+                {
+                    Urgency = PushMessageUrgency.High
+                };
+                await _pushClient.RequestPushMessageDeliveryAsync(pushSub, message);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Push delivery failed for {Endpoint}", sub.Endpoint);
+                if (ex is PushServiceClientException psce && (int)psce.StatusCode is 404 or 410)
+                    stale.Add(sub);
+            }
+        }
+
+        if (stale.Count > 0)
+        {
+            db.PushSubscriptions.RemoveRange(stale);
+            await db.SaveChangesAsync();
+            _logger.LogInformation("Removed {Count} stale push subscriptions", stale.Count);
+        }
+    }
+}

--- a/CampClotNot/Shared/MainLayout.razor
+++ b/CampClotNot/Shared/MainLayout.razor
@@ -2,6 +2,7 @@
 @inject NavigationManager Nav
 @inject ThemeService ThemeSvc
 @inject AuthenticationStateProvider AuthState
+@inject IJSRuntime JS
 
 <ThemeHead />
 <MudThemeProvider IsDarkMode="false" Theme="@_mudTheme" />
@@ -12,6 +13,17 @@
 
 <AppNav OnLeaderboardClick="@(() => _showProjector = true)" />
 
+@if (_showPushBanner)
+{
+    <div style="position:fixed;top:0;left:0;right:0;z-index:100;background:#F5C800;border-bottom:3px solid var(--black);padding:10px 16px;display:flex;align-items:center;justify-content:space-between;gap:10px;animation:fadeIn .2s ease">
+        <span style="font-family:'Fredoka One',cursive;font-size:13px;color:var(--black)">Enable notifications to get camp announcements</span>
+        <div style="display:flex;gap:6px;flex-shrink:0">
+            <button class="ccn-btn" style="font-size:11px;padding:5px 12px" @onclick="EnablePush">Enable</button>
+            <button style="background:none;border:none;font-size:18px;cursor:pointer;color:var(--black);line-height:1" @onclick="() => _showPushBanner = false">✕</button>
+        </div>
+    </div>
+}
+
 <div style="padding:20px 18px calc(80px + env(safe-area-inset-bottom))">
     @Body
 </div>
@@ -20,6 +32,7 @@
 
 @code {
     private bool _showProjector;
+    private bool _showPushBanner;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -27,6 +40,34 @@
         var state = await AuthState.GetAuthenticationStateAsync();
         if (state.User.HasClaim("mustChangePassword", "true"))
             Nav.NavigateTo("/change-password", forceLoad: false);
+
+        if (state.User.Identity?.IsAuthenticated == true)
+        {
+            try
+            {
+                var supported = await JS.InvokeAsync<bool>("ccnPush.isSupported");
+                if (supported)
+                {
+                    var subscribed = await JS.InvokeAsync<bool>("ccnPush.isSubscribed");
+                    if (!subscribed)
+                    {
+                        _showPushBanner = true;
+                        StateHasChanged();
+                    }
+                }
+            }
+            catch { }
+        }
+    }
+
+    private async Task EnablePush()
+    {
+        try
+        {
+            var result = await JS.InvokeAsync<bool>("ccnPush.subscribe");
+            _showPushBanner = false;
+        }
+        catch { _showPushBanner = false; }
     }
 
     private static readonly MudTheme _mudTheme = new()

--- a/CampClotNot/wwwroot/js/push-notifications.js
+++ b/CampClotNot/wwwroot/js/push-notifications.js
@@ -1,0 +1,51 @@
+window.ccnPush = {
+    subscribe: async function () {
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
+
+        var permission = await Notification.requestPermission();
+        if (permission !== 'granted') return false;
+
+        var reg = await navigator.serviceWorker.ready;
+        var keyResponse = await fetch('/api/vapid-public-key');
+        var keyData = await keyResponse.json();
+
+        var sub = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: ccnPush._urlBase64ToUint8Array(keyData.key)
+        });
+
+        var json = sub.toJSON();
+        await fetch('/api/push/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                endpoint: json.endpoint,
+                p256dh: json.keys.p256dh,
+                auth: json.keys.auth
+            })
+        });
+        return true;
+    },
+
+    isSubscribed: async function () {
+        if (!('serviceWorker' in navigator) || !('PushManager' in window)) return false;
+        var reg = await navigator.serviceWorker.ready;
+        var sub = await reg.pushManager.getSubscription();
+        return sub !== null;
+    },
+
+    isSupported: function () {
+        return 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window;
+    },
+
+    _urlBase64ToUint8Array: function (base64String) {
+        var padding = '='.repeat((4 - base64String.length % 4) % 4);
+        var base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        var rawData = window.atob(base64);
+        var outputArray = new Uint8Array(rawData.length);
+        for (var i = 0; i < rawData.length; ++i) {
+            outputArray[i] = rawData.charCodeAt(i);
+        }
+        return outputArray;
+    }
+};

--- a/CampClotNot/wwwroot/service-worker.js
+++ b/CampClotNot/wwwroot/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ccn-shell-v3';
+const CACHE_NAME = 'ccn-shell-v4';
 const SHELL_ASSETS = [
     '/offline.html',
     '/app.css',
@@ -49,6 +49,34 @@ self.addEventListener('fetch', function(event) {
             return cached || fetch(event.request).catch(function() {
                 return caches.match('/offline.html');
             });
+        })
+    );
+});
+
+self.addEventListener('push', function(event) {
+    var data = { title: 'Camp Clot Not', body: 'New announcement', url: '/hub/announcements' };
+    try { data = event.data.json(); } catch(e) {}
+    event.waitUntil(
+        self.registration.showNotification(data.title, {
+            body: data.body,
+            icon: '/icons/icon-192.png',
+            badge: '/icons/icon-192.png',
+            data: { url: data.url || '/hub/announcements' },
+            vibrate: [200, 100, 200]
+        })
+    );
+});
+
+self.addEventListener('notificationclick', function(event) {
+    event.notification.close();
+    var url = event.notification.data && event.notification.data.url ? event.notification.data.url : '/hub/announcements';
+    event.waitUntil(
+        clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function(clientList) {
+            for (var i = 0; i < clientList.length; i++) {
+                if (clientList[i].url.indexOf(url) !== -1 && 'focus' in clientList[i])
+                    return clientList[i].focus();
+            }
+            if (clients.openWindow) return clients.openWindow(url);
         })
     );
 });


### PR DESCRIPTION
## Summary
- **Push notifications**: Web Push via VAPID for announcement alerts. Yellow banner prompts users to enable. Fires on every new announcement post.
- **Data Protection keys persisted in PostgreSQL**: Fixes all users getting logged out on every Railway deploy.

## Setup required
Set these Railway env vars before deploy:
- `Vapid__PublicKey` — (from appsettings.Development.json)
- `Vapid__PrivateKey` — (from appsettings.Development.json)
- `Vapid__Subject` — `mailto:trblair16@gmail.com`

Both migrations already applied to prod.

## Test plan
- [ ] After deploy, verify existing sessions survive (not logged out)
- [ ] Log in, see yellow "Enable notifications" banner, click Enable
- [ ] Post an announcement — all subscribed devices get a push notification
- [ ] Tapping the notification opens /hub/announcements

Refs #160
