### PR TITLE
fix: push NRE — use SetKey instead of Keys initializer

### DIFF
--- a/CampClotNot/Services/PushNotificationService.cs
+++ b/CampClotNot/Services/PushNotificationService.cs
@@ -88,11 +88,9 @@ public class PushNotificationService
         {
             try
             {
-                var pushSub = new Lib.Net.Http.WebPush.PushSubscription
-                {
-                    Endpoint = sub.Endpoint,
-                    Keys = { ["p256dh"] = sub.P256dh, ["auth"] = sub.Auth }
-                };
+                var pushSub = new Lib.Net.Http.WebPush.PushSubscription { Endpoint = sub.Endpoint };
+                pushSub.SetKey(PushEncryptionKeyName.P256DH, sub.P256dh);
+                pushSub.SetKey(PushEncryptionKeyName.Auth, sub.Auth);
                 var message = new PushMessage(payload)
                 {
                     Urgency = PushMessageUrgency.High


### PR DESCRIPTION
## Summary
- Fix NullReferenceException in push delivery: `Keys` dictionary on `PushSubscription` was null. Switched to `SetKey(PushEncryptionKeyName)` API.

Refs #160
