### PR TITLE
fix: all timestamps use Central Time instead of UTC

### DIFF
--- a/CampClotNot/Program.cs
+++ b/CampClotNot/Program.cs
@@ -135,7 +135,7 @@ try
         {
             using var db    = factory.CreateDbContext();
             var activeEvent = await db.Events.FirstOrDefaultAsync(e => e.IsActive);
-            var today       = DateOnly.FromDateTime(DateTime.UtcNow);
+            var today       = CampTime.Today;
             if (activeEvent is not null && today >= activeEvent.EffDate && today <= activeEvent.ExpDate)
                 expiresUtc = new DateTimeOffset(activeEvent.ExpDate.AddDays(1).ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
             else

--- a/CampClotNot/Repositories/TransactionRepository.cs
+++ b/CampClotNot/Repositories/TransactionRepository.cs
@@ -1,5 +1,6 @@
 using CampClotNot.Data;
 using CampClotNot.Data.Entities;
+using CampClotNot.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace CampClotNot.Repositories;
@@ -42,7 +43,7 @@ public class TransactionRepository(IDbContextFactory<AppDbContext> factory) : IT
         var tx = await db.Transactions.FindAsync(txId);
         if (tx is not null && tx.VoidedAt is null)
         {
-            tx.VoidedAt = DateTime.UtcNow;
+            tx.VoidedAt = CampTime.Now;
             tx.VoidedBy = voidedBy;
             await db.SaveChangesAsync();
         }

--- a/CampClotNot/Services/AnnouncementService.cs
+++ b/CampClotNot/Services/AnnouncementService.cs
@@ -15,7 +15,7 @@ public class AnnouncementService(IDbContextFactory<AppDbContext> factory, IMemor
         {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(20);
             using var db = factory.CreateDbContext();
-            var now = DateTime.UtcNow;
+            var now = CampTime.Now;
 
             var expired = await db.Announcements
                 .Where(a => !a.IsArchived && a.ExpiresAt != null && a.ExpiresAt <= now)
@@ -52,7 +52,7 @@ public class AnnouncementService(IDbContextFactory<AppDbContext> factory, IMemor
             Priority       = priority,
             IsPinned       = false,
             AuthorId       = authorId,
-            CreatedAt      = DateTime.UtcNow,
+            CreatedAt      = CampTime.Now,
             IsArchived     = false
         };
         db.Announcements.Add(announcement);

--- a/CampClotNot/Services/BoardService.cs
+++ b/CampClotNot/Services/BoardService.cs
@@ -168,7 +168,7 @@ public class BoardService(
         if (pos is not null)
         {
             pos.SpaceIndex = destination;
-            pos.UpdatedAt  = DateTime.UtcNow;
+            pos.UpdatedAt  = CampTime.Now;
         }
         else
         {
@@ -176,7 +176,7 @@ public class BoardService(
             {
                 GroupId    = groupId,
                 SpaceIndex = destination,
-                UpdatedAt  = DateTime.UtcNow
+                UpdatedAt  = CampTime.Now
             });
         }
 
@@ -204,7 +204,7 @@ public class BoardService(
         foreach (var p in positions)
         {
             p.SpaceIndex = 0;
-            p.UpdatedAt  = DateTime.UtcNow;
+            p.UpdatedAt  = CampTime.Now;
         }
 
         // Un-trigger block hit scripts for the specified day

--- a/CampClotNot/Services/DocumentService.cs
+++ b/CampClotNot/Services/DocumentService.cs
@@ -40,7 +40,7 @@ public class DocumentService(IDbContextFactory<AppDbContext> factory)
             ContentType      = contentType,
             VisibleRoles     = visibleRoles,
             SortOrder        = maxOrder + 1,
-            UploadedAt       = DateTime.UtcNow,
+            UploadedAt       = CampTime.Now,
             UploadedByUserId = uploadedByUserId,
         });
         await db.SaveChangesAsync();

--- a/CampClotNot/Services/IncidentReportService.cs
+++ b/CampClotNot/Services/IncidentReportService.cs
@@ -28,7 +28,7 @@ public class IncidentReportService(IDbContextFactory<AppDbContext> factory)
     {
         using var db = factory.CreateDbContext();
         if (report.IncidentReportId == Guid.Empty) report.IncidentReportId = Guid.NewGuid();
-        report.SubmittedAt = DateTime.UtcNow;
+        report.SubmittedAt = CampTime.Now;
         db.IncidentReports.Add(report);
         await db.SaveChangesAsync();
         return report;
@@ -42,7 +42,7 @@ public class IncidentReportService(IDbContextFactory<AppDbContext> factory)
         report.IsAcknowledged = true;
         report.AcknowledgedByUserId = adminUserId;
         report.AcknowledgedByName = adminName;
-        report.AcknowledgedAt = DateTime.UtcNow;
+        report.AcknowledgedAt = CampTime.Now;
         await db.SaveChangesAsync();
     }
 }

--- a/CampClotNot/Services/InfoPageService.cs
+++ b/CampClotNot/Services/InfoPageService.cs
@@ -68,7 +68,7 @@ public class InfoPageService(IDbContextFactory<AppDbContext> factory, IMemoryCac
         var page = await db.InfoPages.FindAsync(pageId);
         if (page is null) return;
         page.Body = body;
-        page.UpdatedAt = DateTime.UtcNow;
+        page.UpdatedAt = CampTime.Now;
         page.UpdatedByUserId = updatedByUserId;
         await db.SaveChangesAsync();
         cache.Remove(AllKey);
@@ -92,7 +92,7 @@ public class InfoPageService(IDbContextFactory<AppDbContext> factory, IMemoryCac
             page.PdfData        = pdfData;
             page.PdfContentType = pdfContentType;
         }
-        page.UpdatedAt       = DateTime.UtcNow;
+        page.UpdatedAt       = CampTime.Now;
         page.UpdatedByUserId = updatedByUserId;
         await db.SaveChangesAsync();
         cache.Remove(AllKey);

--- a/CampClotNot/Services/PushNotificationService.cs
+++ b/CampClotNot/Services/PushNotificationService.cs
@@ -58,7 +58,7 @@ public class PushNotificationService
                 P256dh = p256dh,
                 Auth = auth,
                 UserId = userId,
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = CampTime.Now
             });
         }
         await db.SaveChangesAsync();

--- a/CampClotNot/Services/ScheduleService.cs
+++ b/CampClotNot/Services/ScheduleService.cs
@@ -116,7 +116,7 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory, IMemoryCac
                 PresenterName      = dto.PresenterName,
                 PresenterBio       = dto.PresenterBio,
                 CreatedBy          = userId,
-                UpdatedAt          = DateTime.UtcNow,
+                UpdatedAt          = CampTime.Now,
                 ItemGroups         = dto.Assignments
                     .Select(a => new ScheduleItemGroup
                     {
@@ -146,7 +146,7 @@ public class ScheduleService(IDbContextFactory<AppDbContext> factory, IMemoryCac
             existing.MaxCapacity        = dto.MaxCapacity;
             existing.PresenterName      = dto.PresenterName;
             existing.PresenterBio       = dto.PresenterBio;
-            existing.UpdatedAt          = DateTime.UtcNow;
+            existing.UpdatedAt          = CampTime.Now;
 
             db.ScheduleItemGroups.RemoveRange(existing.ItemGroups);
             existing.ItemGroups = dto.Assignments

--- a/CampClotNot/Services/TransactionService.cs
+++ b/CampClotNot/Services/TransactionService.cs
@@ -24,7 +24,7 @@ public class TransactionService(
             Amount = amount,
             LoggedBy = loggedBy,
             Note = note,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = CampTime.Now
         });
         await hub.Clients.All.SendAsync("ScoresUpdated");
         return tx;


### PR DESCRIPTION
## Summary
- Replace all `DateTime.UtcNow` with `CampTime.Now` (Central Time) across all services
- Fixes timestamps showing 5 hours ahead on announcements, transactions, incidents, documents, schedule items, board positions

Refs #160
