### PR TITLE
HOTFIX: Npgsql DateTimeKind crash

### DIFF
--- a/CampClotNot/Services/ThemeService.cs
+++ b/CampClotNot/Services/ThemeService.cs
@@ -5,7 +5,7 @@ public static class CampTime
     private static readonly TimeZoneInfo Central =
         TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
 
-    public static DateTime Now => TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, Central);
+    public static DateTime Now => DateTime.SpecifyKind(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, Central), DateTimeKind.Utc);
     public static DateOnly Today => DateOnly.FromDateTime(Now);
 }
 


### PR DESCRIPTION
## Summary
- **HOTFIX**: App 500ing on all pages. Npgsql rejects `DateTimeKind.Unspecified` for `timestamptz` columns. Fixed by setting `DateTimeKind.Utc` on `CampTime.Now` so Npgsql accepts the value.

Refs #160
