### PR TITLE
fix: dialog text selection no longer closes modal

### DIFF
--- a/CampClotNot/Pages/Admin/Activities.razor
+++ b/CampClotNot/Pages/Admin/Activities.razor
@@ -29,9 +29,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-act-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 300px;min-width:240px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">@(_editingId == Guid.Empty ? "Add Activity" : "Edit Activity")</h3>
                 @if (_mobileFormOpen)

--- a/CampClotNot/Pages/Admin/Groups.razor
+++ b/CampClotNot/Pages/Admin/Groups.razor
@@ -26,9 +26,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-grp-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 320px;min-width:260px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">@(_editing is null ? "Add Group" : "Edit Group")</h3>
                 @if (_mobileFormOpen)

--- a/CampClotNot/Pages/Admin/Locations.razor
+++ b/CampClotNot/Pages/Admin/Locations.razor
@@ -25,9 +25,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-loc-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 300px;min-width:240px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">@(_editingId == Guid.Empty ? "Add Location" : "Edit Location")</h3>
                 @if (_mobileFormOpen)

--- a/CampClotNot/Pages/Admin/Schedule.razor
+++ b/CampClotNot/Pages/Admin/Schedule.razor
@@ -34,9 +34,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-sched-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 340px;min-width:280px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             @if (!string.IsNullOrEmpty(_copyingFromTitle))
             {
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:4px;font-family:'Nunito',sans-serif">Copying: @_copyingFromTitle</div>

--- a/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
+++ b/CampClotNot/Pages/Admin/ScheduleItemTypes.razor
@@ -39,9 +39,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-sit-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 320px;min-width:260px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">@(_editingId == Guid.Empty ? "Add Type" : "Edit Type")</h3>
                 @if (_mobileFormOpen)

--- a/CampClotNot/Pages/Admin/Sponsors.razor
+++ b/CampClotNot/Pages/Admin/Sponsors.razor
@@ -25,9 +25,9 @@
 
         @* ── Form panel (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseFormOverlay">
+             @onmousedown="CloseFormOverlay">
         <div class="admin-spo-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 320px;min-width:260px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">@(_editingId == Guid.Empty ? "Add Sponsor" : "Edit Sponsor")</h3>
                 @if (_mobileFormOpen)

--- a/CampClotNot/Pages/Admin/Users.razor
+++ b/CampClotNot/Pages/Admin/Users.razor
@@ -28,9 +28,9 @@
 
         @* ── Create Account form (desktop) / mobile overlay ── *@
         <div style="@(_mobileFormOpen ? "position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;overflow-y:auto;display:flex;align-items:flex-start;justify-content:center;padding:16px;animation:fadeIn .15s ease" : "display:contents")"
-             @onclick="CloseCreateOverlay">
+             @onmousedown="CloseCreateOverlay">
         <div class="admin-usr-form" style="background:var(--panel-bg);border:3px solid var(--black);border-radius:10px;box-shadow:@(_mobileFormOpen ? "8px 8px 0 var(--black)" : "4px 4px 0 var(--black)");padding:20px;flex:0 0 320px;min-width:260px;@(_mobileFormOpen ? "display:block !important;max-width:480px;width:100%;margin:auto;animation:popIn .2s ease" : "")"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:16px;margin:0">Create Account</h3>
                 @if (_mobileFormOpen)
@@ -233,9 +233,9 @@
 @if (_editOpen)
 {
     <div style="position:fixed;inset:0;background:rgba(26,26,26,.6);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .15s ease"
-         @onclick="CloseEditDialog">
+         @onmousedown="CloseEditDialog">
         <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:12px;box-shadow:6px 6px 0 var(--black);padding:24px;width:100%;max-width:440px;animation:popIn .2s ease"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <h3 style="font-family:'Fredoka One',cursive;font-size:18px;margin:0 0 18px">Edit User</h3>
 
             <div style="display:flex;gap:10px;margin-bottom:14px">
@@ -302,9 +302,9 @@
 @if (_resetOpen)
 {
     <div style="position:fixed;inset:0;background:rgba(26,26,26,.6);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .15s ease"
-         @onclick="CloseResetDialog">
+         @onmousedown="CloseResetDialog">
         <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:12px;box-shadow:6px 6px 0 var(--black);padding:24px;width:100%;max-width:400px;animation:popIn .2s ease"
-             @onclick:stopPropagation>
+             @onmousedown:stopPropagation>
             <h3 style="font-family:'Fredoka One',cursive;font-size:18px;margin:0 0 18px">Reset Password</h3>
             <p style="font-size:13px;color:var(--text-light);margin:0 0 16px">@_resetting?.FirstName @_resetting?.LastName</p>
 

--- a/CampClotNot/Pages/Hub/HubSubNav.razor
+++ b/CampClotNot/Pages/Hub/HubSubNav.razor
@@ -110,10 +110,10 @@
     <div style="position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;
                 display:flex;align-items:center;justify-content:center;padding:20px;
                 animation:fadeIn .2s ease"
-         @onclick="CloseModal">
+         @onmousedown="CloseModal">
         <div class="ccn-panel" style="padding:24px;width:100%;max-width:500px;max-height:90vh;overflow-y:auto;
                                       box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease"
-             @onclick:stopPropagation="true">
+             @onmousedown:stopPropagation="true">
             <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px">
                 <h3 style="font-family:'Fredoka One',cursive;font-size:18px;margin:0"><img src="/img/icons/alert.svg" style="width:18px;height:18px;vertical-align:middle;margin-right:5px;opacity:.8" alt="" />Report Incident</h3>
                 <button style="background:none;border:none;font-size:20px;cursor:pointer;color:var(--text-mid)" @onclick="CloseModal">✕</button>

--- a/CampClotNot/Pages/Hub/Schedule.razor
+++ b/CampClotNot/Pages/Hub/Schedule.razor
@@ -470,8 +470,8 @@
 
 @if (_showForm)
 {
-    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .2s ease" @onclick="CloseForm">
-        <div class="ccn-panel" style="padding:24px;width:100%;max-width:680px;max-height:90vh;overflow-y:auto;box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease" @onclick:stopPropagation>
+    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px;animation:fadeIn .2s ease" @onmousedown="CloseForm">
+        <div class="ccn-panel" style="padding:24px;width:100%;max-width:680px;max-height:90vh;overflow-y:auto;box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease" @onmousedown:stopPropagation>
             @if (!string.IsNullOrEmpty(_copyingFromTitle))
             {
                 <div style="font-size:10px;font-weight:900;letter-spacing:1.5px;text-transform:uppercase;color:var(--text-light);margin-bottom:4px;font-family:'Nunito',sans-serif">Copying: @_copyingFromTitle</div>

--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -111,8 +111,8 @@
 @* ── Add / Edit modal ── *@
 @if (_showForm && _isAdmin)
 {
-    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px" @onclick="Close">
-        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:12px;box-shadow:4px 4px 0 var(--black);padding:24px;width:100%;max-width:400px" @onclick:stopPropagation>
+    <div style="position:fixed;inset:0;background:rgba(26,26,26,.5);z-index:100;display:flex;align-items:center;justify-content:center;padding:16px" @onmousedown="Close">
+        <div style="background:var(--panel-bg);border:3px solid var(--black);border-radius:12px;box-shadow:4px 4px 0 var(--black);padding:24px;width:100%;max-width:400px" @onmousedown:stopPropagation>
             <h3 style="font-family:'Fredoka One',cursive;margin:0 0 16px">@(_form.StaffMemberId == Guid.Empty ? "Add Staff Member" : "Edit Staff Member")</h3>
             <MudTextField @bind-Value="_form.DisplayName" Label="Name" Required="true" Class="mb-2" />
             <MudTextField @bind-Value="_form.RoleTitle"   Label="Role/Title" Class="mb-2" />

--- a/CampClotNot/Shared/LogTransactionDialog.razor
+++ b/CampClotNot/Shared/LogTransactionDialog.razor
@@ -7,10 +7,10 @@
     <div style="position:fixed;inset:0;background:rgba(26,26,26,.65);z-index:100;
                 display:flex;align-items:center;justify-content:center;padding:20px;
                 animation:fadeIn .2s ease"
-         @onclick="Close">
+         @onmousedown="Close">
         <div class="ccn-panel" style="padding:24px;width:100%;max-width:420px;
                                       box-shadow:8px 8px 0 var(--black);animation:popIn .25s ease"
-             @onclick:stopPropagation="true">
+             @onmousedown:stopPropagation="true">
 
             <div style="font-family:'Fredoka One',cursive;font-size:22px;color:var(--black);margin-bottom:18px">
                 ＋ Log Transaction


### PR DESCRIPTION
## Summary
- Fix dialog closing when selecting text: changed backdrop close from `@onclick` to `@onmousedown` across all 11 modal dialogs. Click-drag to select text no longer triggers backdrop close.

Refs #160
