### PR TITLE
fix: staff drag-and-drop drop target

### DIFF
--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -71,7 +71,7 @@
         {
             <div style="font-size:11px;color:var(--text-light);margin-bottom:8px">Drag cards to reorder. Changes save immediately.</div>
         }
-        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px">
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px" @ondragover:preventDefault="true">
             @for (int i = 0; i < _members.Count; i++)
             {
                 var idx = i;


### PR DESCRIPTION
## Summary
- Fix staff drag-and-drop: added `@ondragover:preventDefault` to grid container so drops are accepted

Refs #160
