### PR TITLE
Merge dev to main — staff drag child fix

### DIFF
--- a/CampClotNot/Pages/Hub/Staff.razor
+++ b/CampClotNot/Pages/Hub/Staff.razor
@@ -76,30 +76,30 @@
             {
                 var idx = i;
                 var m = _members[idx];
-                <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center;display:flex;flex-direction:column;@(_isAdmin ? "cursor:grab" : "")"
+                <div style="border:3px solid var(--black);border-radius:10px;padding:16px;box-shadow:3px 3px 0 var(--black);background:var(--panel-bg);text-align:center;display:flex;flex-direction:column;@(_isAdmin ? "cursor:grab;user-select:none" : "")"
                      draggable="@(_isAdmin ? "true" : "false")"
                      @ondragstart="() => _dragIndex = idx"
                      @ondragover:preventDefault="true"
                      @ondrop="() => DropAsync(idx)">
                     @if (m.PhotoContentType is not null)
                     {
-                        <img src="/staff-photo/@m.StaffMemberId"
-                             style="width:100%;aspect-ratio:1/1;object-fit:cover;object-position:@(m.PhotoObjectPosition ?? "50% 50%");border-radius:8px;border:2px solid var(--black);margin-bottom:8px;display:block"
+                        <img src="/staff-photo/@m.StaffMemberId" draggable="false"
+                             style="width:100%;aspect-ratio:1/1;object-fit:cover;object-position:@(m.PhotoObjectPosition ?? "50% 50%");border-radius:8px;border:2px solid var(--black);margin-bottom:8px;display:block;pointer-events:none"
                              alt="@m.DisplayName" />
                     }
                     else
                     {
-                        <div style="width:100%;aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;font-size:48px;border-radius:8px;border:2px solid var(--black);margin-bottom:8px;background:#F5F0E4">@m.AvatarEmoji</div>
+                        <div style="width:100%;aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;font-size:48px;border-radius:8px;border:2px solid var(--black);margin-bottom:8px;background:#F5F0E4;pointer-events:none">@m.AvatarEmoji</div>
                     }
-                    <div style="font-family:'Fredoka One',cursive;font-size:15px">@m.DisplayName</div>
-                    <div style="font-size:12px;color:var(--text-light);margin-bottom:8px">@m.RoleTitle</div>
+                    <div style="font-family:'Fredoka One',cursive;font-size:15px;pointer-events:none">@m.DisplayName</div>
+                    <div style="font-size:12px;color:var(--text-light);margin-bottom:8px;pointer-events:none">@m.RoleTitle</div>
                     @if (!string.IsNullOrEmpty(m.Phone))
                     {
-                        <a href="@TelHref(m.Phone)" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none;margin-bottom:4px">@m.Phone</a>
+                        <a href="@TelHref(m.Phone)" draggable="false" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none;margin-bottom:4px;@(_isAdmin ? "pointer-events:none" : "")">@m.Phone</a>
                     }
                     @if (!string.IsNullOrEmpty(m.Email))
                     {
-                        <a href="mailto:@m.Email" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none;overflow-wrap:break-word;word-break:break-all">@m.Email</a>
+                        <a href="mailto:@m.Email" draggable="false" style="display:block;font-size:13px;color:#1a5fa8;text-decoration:none;overflow-wrap:break-word;word-break:break-all;@(_isAdmin ? "pointer-events:none" : "")">@m.Email</a>
                     }
                     @if (m.LinkedUserId.HasValue)
                     {


### PR DESCRIPTION
## Summary
- Fix staff drag-and-drop: child images/links were intercepting the card drag. Added `draggable=false`, `pointer-events:none`, and `user-select:none` so the whole card drags cleanly. Phone/email links still clickable for non-admin users.

Refs #160
