### PR TITLE
fix: replace Bowser free star with -5 coins

### DIFF
--- a/CampClotNot/Services/BowserEventService.cs
+++ b/CampClotNot/Services/BowserEventService.cs
@@ -20,7 +20,7 @@ public class BowserEventService(
         new("−20 Coins",  "Bowser nabs 20 coins!",           "😤", -20, 0),
         new("+10 Coins",  "Bowser drops 10 coins!",          "😅", +10, 0),
         new("+15 Coins",  "Bowser fumbles 15 coins!",        "😏", +15, 0),
-        new("FREE STAR",  "Bowser accidentally gives a star!","⭐",  0, 1),
+        new("−5 Coins",   "Bowser pinches 5 coins!",           "😈", -5, 0),
     ];
 
     private static readonly Random _rng = new();


### PR DESCRIPTION
## Summary
- Replaced the FREE STAR Bowser die face with -5 Coins face

## Test plan
- [ ] Verify Bowser Event roll no longer awards stars
- [ ] Confirm -5 coins face applies correct coin deduction