### PR TITLE
perf: remove Material Icons, defer Google Fonts

### DIFF
--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -9,8 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>Camp Clot Not</title>
     <base href="~/" />
-    <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@400;600&display=swap" rel="stylesheet" /></noscript>
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="app.css?v=8" rel="stylesheet" />
     @RenderSection("HeadOutlet", required: false)


### PR DESCRIPTION
## Summary
- Removed unused Material Icons stylesheet (750ms render-blocking)
- Added preconnect hints for Google Fonts CDN
- Deferred font CSS loading with media=print onload pattern

## Test plan
- [ ] Verify Fredoka One and Nunito fonts still load correctly
- [ ] Check no Material Icons are missing anywhere