### PR TITLE
fix: PWA icon stuck on old branding for Android users (immutable cache)

### DIFF
--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -18,12 +18,12 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="app.css?v=8" rel="stylesheet" />
     @RenderSection("HeadOutlet", required: false)
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json?v=2" />
     <meta name="theme-color" content="#3d0066" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="HBDA Events" />
-    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png?v=2" />
 </head>
 <body>
     <div id="app-loading" style="position:fixed;inset:0;z-index:10000;background:var(--bg-base,#F2ECD8);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;transition:opacity .3s ease">

--- a/CampClotNot/wwwroot/manifest.json
+++ b/CampClotNot/wwwroot/manifest.json
@@ -8,10 +8,10 @@
   "theme_color": "#F2ECD8",
   "orientation": "portrait-primary",
   "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/icon-192.png?v=2", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png?v=2", "sizes": "512x512", "type": "image/png" },
     {
-      "src": "/icons/icon-512-maskable.png",
+      "src": "/icons/icon-512-maskable.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/CampClotNot/wwwroot/service-worker.js
+++ b/CampClotNot/wwwroot/service-worker.js
@@ -1,11 +1,11 @@
-const CACHE_NAME = 'ccn-shell-v8';
+const CACHE_NAME = 'ccn-shell-v9';
 const SHELL_ASSETS = [
     '/offline.html',
     '/app.css?v=8',
     '/_content/MudBlazor/MudBlazor.min.css',
     '/_content/MudBlazor/MudBlazor.min.js',
-    '/icons/icon-192.png',
-    '/icons/icon-512.png'
+    '/icons/icon-192.png?v=2',
+    '/icons/icon-512.png?v=2'
 ];
 const SKIP_PREFIXES = ['/livehub', '/account/', '/api/'];
 
@@ -59,8 +59,8 @@ self.addEventListener('push', function(event) {
     event.waitUntil(
         self.registration.showNotification(data.title, {
             body: data.body,
-            icon: '/icons/icon-192.png',
-            badge: '/icons/icon-192.png',
+            icon: '/icons/icon-192.png?v=2',
+            badge: '/icons/icon-192.png?v=2',
             data: { url: data.url || '/hub/announcements' },
             vibrate: [200, 100, 200]
         })


### PR DESCRIPTION
## Summary
- Not a cookie or race-condition issue — it's HTTP caching. `Program.cs` serves `.png`/`.js`/`.css` static files with `Cache-Control: public, max-age=31536000, immutable`. Commit `1f45f6e` swapped the `icon-192/512(-maskable).png` bytes in place under the *same filenames* to rebrand CCN → HBDA Events, but `immutable` tells every cache — browser disk cache, any CDN, and specifically **Android Chrome's WebAPK minting service** (the thing that actually bakes the Android home-screen icon) — to never revalidate that URL for a year
- Anyone who'd already fetched the old icon once keeps getting served the stale bytes indefinitely, and uninstalling/reinstalling the PWA doesn't clear the browser's underlying HTTP cache, so it doesn't fix it
- iOS Safari fetches the touch icon directly at the moment "Add to Home Screen" is tapped rather than going through a remote minting/caching service the way Android does, which is why iOS wasn't affected
- Bumping the service worker's `CACHE_NAME` (already attempted in `1f45f6e`) didn't help — that only covers the SW's own Cache Storage, not the raw browser HTTP cache or the WebAPK layer

## Fix
Add `?v=2` to every manifest/icon reference — `manifest.json`'s icon `src`s, `<link rel="manifest">`, `<link rel="apple-touch-icon">`, and the service worker's shell assets + push notification `icon`/`badge` — the same cache-busting pattern already used for `app.css?v=8`. A new URL can't be served from the old immutable cache entry, forcing every layer (browser, CDN, Android's WebAPK service) to fetch the new bytes. Any future icon swap needs to bump this version again, or reuse the same query-string convention.

## Test plan
- [ ] Deploy; on an Android device that previously installed the PWA with the old CCN icon, revisit the site in Chrome (not the installed app) to let it pick up the new manifest, then reinstall — icon should now be correct
- [ ] Confirm iOS install still shows the correct icon (unaffected, but verifying no regression)
- [ ] Confirm push notifications still show the correct icon/badge


---
_Generated by [Claude Code](https://claude.ai/code/session_01DtbJceKkB28tsjswX6uy5G)_