### PR TITLE
fix: remove remaining hardcoded CCN branding (/join logo, theme-color meta)

### DIFF
--- a/CampClotNot/Pages/Join.razor
+++ b/CampClotNot/Pages/Join.razor
@@ -1,10 +1,12 @@
 @page "/join"
 @layout LoginLayout
 
-<PageTitle>Join Event — Camp Clot Not</PageTitle>
+<PageTitle>Join Event — HBDA Events</PageTitle>
 
-<img src="/img/ccn-logo-2026.webp?v=2" alt="Camp Clot Not" fetchpriority="high"
-     style="position:fixed;bottom:calc(50% + 195px);left:50%;transform:translateX(-50%);width:clamp(120px,25vw,180px);height:auto;pointer-events:none" />
+@* No event is known yet at this point — that's what the code entry below is for — so this
+   uses the generic HBDA mark rather than any single event's theme/logo. *@
+<img src="/icons/icon-512.png?v=2" alt="HBDA Events" fetchpriority="high"
+     style="position:fixed;bottom:calc(50% + 195px);left:50%;transform:translateX(-50%);width:clamp(90px,18vw,130px);height:auto;pointer-events:none" />
 
 <div class="ccn-panel"
      style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:min(340px,calc(100vw - 32px));padding:20px">

--- a/CampClotNot/Pages/_Layout.cshtml
+++ b/CampClotNot/Pages/_Layout.cshtml
@@ -19,7 +19,7 @@
     <link href="app.css?v=8" rel="stylesheet" />
     @RenderSection("HeadOutlet", required: false)
     <link rel="manifest" href="/manifest.json?v=2" />
-    <meta name="theme-color" content="#3d0066" />
+    <meta name="theme-color" content="@ThemeSvc.Active.Primary" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="HBDA Events" />


### PR DESCRIPTION
## Summary
Follow-up to the guest nav theme fix (#300) — found two more spots hardcoding CCN branding while auditing for the same bug class:

- `/join` — the first screen any guest sees, before they've typed an event code, hardcoded the CCN Mario logo (`ccn-logo-2026.webp`). There's no known event/theme at that point (that's what the code entry is for), so it now shows the generic HBDA icon instead, with a matching page title.
- `<meta name="theme-color">` in `_Layout.cshtml` was hardcoded to `#3d0066`, a purple that doesn't match any event's actual palette (not even CCN's gold/black) — this drives the Android PWA status bar/toolbar tint. Now resolves from `ThemeSvc.Active.Primary`, same as the rest of the page chrome.

## Test plan
- [ ] Visit `/join` fresh (logged out, no event cookie) — confirm generic HBDA icon shows, not the CCN logo
- [ ] Install the PWA for an event with a distinct theme color and confirm the Android status bar tint matches that event's primary color
- [ ] Confirm CCN's own install still looks correct (no regression)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DtbJceKkB28tsjswX6uy5G)_